### PR TITLE
fix(deps): add numpy/scipy for graph metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "tree-sitter>=0.23",
     "tree-sitter-language-pack>=0.6",
     "networkx>=3.0",
+    "numpy>=1.26",
     "scipy>=1.8",
 ]
 


### PR DESCRIPTION
Adds missing runtime dependencies for graph-metrics indexing.

- add numpy>=1.26
- add scipy>=1.8

Without these, a fresh editable install can fail during roam index when metric computation runs.