### PR TITLE
feat(fitness): support edge_kinds filter on dependency rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`edge_kinds` filter on dependency rules** — dependency rules in
+  `.roam/fitness.yaml` now accept an optional `edge_kinds: [import]`
+  field.  When set, only edges whose kind matches one of the listed
+  values are evaluated; edges of all other kinds are skipped.
+  Backwards-compatible: rules without `edge_kinds` behave exactly as
+  before.  This eliminates high false-positive rates caused by
+  name-based edge matching across unrelated symbols (e.g. a local
+  variable named `Settings` matching a `Settings` component from a
+  different module even though there is no real import).
+
+  Example:
+
+  ```yaml
+  - name: V2 must not import legacy v1 components
+    type: dependency
+    from: "frontend/v2/**"
+    to: "frontend/components/**"
+    edge_kinds: [import]
+  ```
+
 ## [12.46] - 2026-05-07
 
 ### CI fix — ruff lint cleanup on overnight files

--- a/src/roam/commands/cmd_fitness.py
+++ b/src/roam/commands/cmd_fitness.py
@@ -18,6 +18,7 @@ Example .roam/fitness.yaml:
       from: "**/services/**"
       to: "**/controllers/**"
       allow: false
+      edge_kinds: [import]   # optional: restrict to import edges only
 
     - name: "Max function complexity"
       type: metric
@@ -137,10 +138,17 @@ def _check_dependency_rule(rule, conn) -> list[dict]:
 
     Verifies that symbols in 'from' glob don't have edges to symbols
     in 'to' glob (or vice versa if allow=true).
+
+    Optional ``edge_kinds`` field restricts the check to specific edge
+    kinds (e.g. ``[import]``).  When omitted all edge kinds are matched,
+    preserving the existing behaviour.
     """
     from_pattern = rule.get("from", "**")
     to_pattern = rule.get("to", "**")
     allow = rule.get("allow", False)
+    edge_kinds = rule.get("edge_kinds")  # None → match all kinds (backwards-compatible)
+    if edge_kinds is not None and not isinstance(edge_kinds, list):
+        edge_kinds = [edge_kinds]
 
     # Get all edges with file paths
     rows = conn.execute(
@@ -158,6 +166,8 @@ def _check_dependency_rule(rule, conn) -> list[dict]:
 
     violations = []
     for r in rows:
+        if edge_kinds is not None and r["kind"] not in edge_kinds:
+            continue
         src_match = matches_gitignore(r["source_path"], from_pattern)
         tgt_match = matches_gitignore(r["target_path"], to_pattern)
 

--- a/tests/test_fitness_edge_kinds.py
+++ b/tests/test_fitness_edge_kinds.py
@@ -1,0 +1,158 @@
+"""Tests for the edge_kinds filter on dependency rules.
+
+Exercises _check_dependency_rule() directly using a lightweight
+in-memory sqlite3 connection so no filesystem project or real index
+is required.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn() -> sqlite3.Connection:
+    """Return an in-memory sqlite3 connection with the minimal schema used by
+    _check_dependency_rule().  Uses row_factory=sqlite3.Row to match the real
+    roam DB so r["kind"] etc. work identically."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    conn.executescript("""
+        CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE symbols (
+            id INTEGER PRIMARY KEY,
+            file_id INTEGER,
+            name TEXT,
+            kind TEXT,
+            line_start INTEGER
+        );
+        CREATE TABLE edges (
+            source_id INTEGER,
+            target_id INTEGER,
+            kind TEXT,
+            line INTEGER
+        );
+
+        -- Two files: src/v2/Widget.tsx  and  src/components/Legacy.tsx
+        INSERT INTO files VALUES (1, 'src/v2/Widget.tsx'), (2, 'src/components/Legacy.tsx');
+
+        -- Symbols
+        INSERT INTO symbols VALUES
+            (10, 1, 'Widget',   'class',    1),
+            (20, 2, 'Legacy',   'class',    1),
+            (30, 1, 'settings', 'variable', 5),
+            (40, 2, 'Settings', 'class',    5);
+
+        -- Two edges between the same pair of files:
+        --   - a real import edge  (Widget -> Legacy)
+        --   - a call edge         (settings -> Settings) — name-match FP scenario
+        INSERT INTO edges VALUES
+            (10, 20, 'import', 3),
+            (30, 40, 'call',   6);
+    """)
+    return conn
+
+
+def _rule(name: str, from_pat: str, to_pat: str, edge_kinds=None) -> dict:
+    r: dict = {
+        "name": name,
+        "type": "dependency",
+        "from": from_pat,
+        "to": to_pat,
+        "allow": False,
+    }
+    if edge_kinds is not None:
+        r["edge_kinds"] = edge_kinds
+    return r
+
+
+@pytest.fixture()
+def conn():
+    return _make_conn()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeKindsFilter:
+    def test_no_filter_sees_both_edges(self, conn):
+        """Without edge_kinds, all edge kinds (import + call) are matched."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("all-edges", "src/v2/**", "src/components/**"),
+            conn,
+        )
+        assert len(violations) == 2
+
+    def test_import_filter_sees_only_import_edge(self, conn):
+        """edge_kinds: [import] skips the call edge — only the true import fires."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("import-only", "src/v2/**", "src/components/**", edge_kinds=["import"]),
+            conn,
+        )
+        assert len(violations) == 1
+        assert violations[0]["edge_kind"] == "import"
+
+    def test_call_filter_sees_only_call_edge(self, conn):
+        """edge_kinds: [call] skips the import edge."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("call-only", "src/v2/**", "src/components/**", edge_kinds=["call"]),
+            conn,
+        )
+        assert len(violations) == 1
+        assert violations[0]["edge_kind"] == "call"
+
+    def test_unknown_kind_produces_no_violations(self, conn):
+        """Filtering by a kind that doesn't exist returns an empty list."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("noop", "src/v2/**", "src/components/**", edge_kinds=["type"]),
+            conn,
+        )
+        assert violations == []
+
+    def test_scalar_string_is_coerced_to_list(self, conn):
+        """edge_kinds: import (bare string, no brackets in YAML) still works."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("scalar-str", "src/v2/**", "src/components/**", edge_kinds="import"),
+            conn,
+        )
+        assert len(violations) == 1
+        assert violations[0]["edge_kind"] == "import"
+
+    def test_multi_kind_filter(self, conn):
+        """edge_kinds: [import, call] passes both edges through."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("multi", "src/v2/**", "src/components/**", edge_kinds=["import", "call"]),
+            conn,
+        )
+        assert len(violations) == 2
+
+    def test_no_violations_when_globs_dont_match(self, conn):
+        """edge_kinds filter does not affect glob matching: non-matching globs still pass."""
+        from roam.commands.cmd_fitness import _check_dependency_rule
+
+        violations = _check_dependency_rule(
+            _rule("no-match", "src/legacy/**", "src/components/**", edge_kinds=["import"]),
+            conn,
+        )
+        assert violations == []


### PR DESCRIPTION
Adds an optional `edge_kinds: [import]` field to dependency rules in `.roam/fitness.yaml` so they can filter to specific edge kinds instead of matching all edges between glob-matching files.

## Motivation

In real-world codebases the dependency rule generates high false-positive rates because a local variable named `Settings` matches an unrelated `Settings` symbol from another file even when there is no actual import. Filtering by `edge_kinds: [import]` suppresses those FPs and makes dep rules useful again.

Validated against an AdviseWell codebase (3058 files, 28k symbols): a V2→components rule went from 697 violations (mostly FPs) to a handful of true import leaks.

## Backwards compatibility

Existing rules without `edge_kinds` work exactly as before — the filter is opt-in (`None` = match all kinds).

## Example

```yaml
- name: V2 must not import legacy v1 components
  type: dependency
  from: "frontend/v2/**"
  to: "frontend/components/**"
  edge_kinds: [import]
```

## Changes

- `src/roam/commands/cmd_fitness.py` — `_check_dependency_rule()`: read optional `edge_kinds` from rule dict; coerce scalar string to list for YAML bare-string compat; skip edges whose `kind` is not in the list.
- `tests/test_fitness_edge_kinds.py` — 7 unit tests exercising the filter with an in-memory sqlite3 DB (no subprocess / real index needed). All pass.
- `CHANGELOG.md` — note under `[Unreleased]`.

## Scalar string support

YAML permits both forms:

```yaml
edge_kinds: [import]   # list — preferred
edge_kinds: import     # bare string — also works (coerced internally)
```