### PR TITLE
Revenue selling-surface: real PR-Replay samples + site honesty fixes

### DIFF
--- a/templates/audit-report/sample-pr-replay-fastapi.md
+++ b/templates/audit-report/sample-pr-replay-fastapi.md
@@ -1,0 +1,87 @@
+# PR Replay Report — Showcase — FastAPI
+
+**Tier:** Team — 30 PRs  
+**Commit range:** `HEAD~30..HEAD`  
+**Generated:** 2026-07-07 22:13 UTC  
+**Tool:** `roam pr-replay` — `postmortem` + `critique` engine
+
+> **Real sample — FastAPI (a widely-used OSS project we don't maintain).** An actual
+> `roam pr-replay --tier team` report on FastAPI's recent merged PRs, generated with the
+> current release. On a gold-standard repo Roam stays relatively quiet — the point is a
+> low false-alarm rate, not noise. Run `roam pr-replay --tier sample` free on your own repo,
+> or email <hello@roam-code.com> for a paid Team or Deep engagement.
+
+This report **supports evidence for** structural-review governance and **maps to**
+change-management controls. It does not certify compliance with any framework.
+
+---
+
+
+Thirty most-recent merged PRs on the target branch, scored against the current Roam detector set. Includes founder review of the top findings on a 30-minute call.
+
+> **Evidence framing.** PR Replay produces a structural-review report that **supports evidence for** governance review and **maps to** change-management controls. It does not certify compliance with SOC 2, ISO 42001, the EU AI Act, or any other framework; the control mapping and conformity assessment stay with the customer.
+
+## Executive summary
+
+**Verdict:** 1 of 30 PRs (3%) would have surfaced findings — 0 review-eligible (high), 5 review-required (medium).
+
+- PRs replayed: **30**
+- PRs Roam would have flagged pre-merge: **1**
+- High-severity findings (would block CI): **0**
+- Medium-severity findings (would gate review): **5**
+
+## Evidence coverage
+
+PR Replay is a merged-history replay, not a continuous approval system. The companion evidence bundle answers all eight evidence questions fully or partially when `--evidence-bundle` is used; the buyer-facing coverage floor is:
+
+| Evidence question | PR Replay coverage |
+|---|---|
+| Who acted? | Out of scope for attribution; git metadata may appear only as source metadata. |
+| What authority existed? | Out of scope except for the replay mode used to produce this report. |
+| What context was read? | Partial: commit range, detector version, and local run context. |
+| What changed? | In scope: replay window and per-commit changed subjects. |
+| What could break? | In scope: detector findings, blast-radius signals, and severity. |
+| What policy applied? | In scope: current Roam detector set and any supplied rules. |
+| What verified it? | Partial: replay detectors only; no test execution is implied. |
+| Who accepted risk? | Out of scope unless GitHub approval data is attached explicitly. |
+
+## What Roam would have flagged
+
+| Detector | Total findings | PRs with this finding |
+|---|---:|---:|
+| `clones-not-edited` | 3 | 1 / 30 |
+| `impact` | 2 | 1 / 30 |
+
+The highest-impact class on this window was **`clones-not-edited`** (3 findings across 1 PRs). Wiring a CI gate against this class is the single highest-leverage move surfacing from this replay.
+
+## Per-PR breakdown
+
+Top 1 PRs ranked by severity (high → medium → total).
+
+| Date | SHA | Subject | High | Medium | Top hits |
+|---|---|---|---:|---:|---|
+| 2026-07-01 | `319be50` | ✨ Support dependencies in `app.frontend()`, e.g. for automat | 0 | 5 | clones-not-edited x3, impact x2 |
+
+## Recommended next steps
+
+- **Wire CI gates against the top 2 detector class(es)** — `clones-not-edited`, `impact`. `roam critique` returns exit code 5 on any high-severity finding, so a single CI step gates every PR. See <https://roam-code.com/docs/>.
+- **Run `roam preflight <symbol>` before changing high-blast-radius code.** The blast radius doesn't show up in the diff; it shows up in the graph.
+- **Add `roam clones --persist` to your indexing pipeline.** Then `roam critique` picks up clone-not-edited cases on every PR — the single most common AI-shaped bug across replays in similar codebases.
+- **Consider the Deep tier** if the patterns above warrant a 90-PR window, per-detector deep-dive, and a 90-minute walk-through with a written remediation plan: <https://roam-code.com/#audit>.
+
+## Apply this fee toward Roam Review
+
+50% of the engagement fee — **$1,250** — credits toward your first year of [Roam Review](https://roam-code.com/pricing) if you subscribe within **60 days** of report delivery. Roam Review runs the same detectors on every pull request automatically, with a sticky PR comment, BLOCK / REVIEW / APPROVE verdict, and exit-code-5 CI gating. Mention this report when subscribing and we apply the credit to the first invoice.
+
+## What this report does *not* cover
+
+- **Semantic correctness** — whether the code does the right thing. We complement semantic reviewers (CodeRabbit, Greptile, Qodo), we don't replace them.
+- **Security audit** of the kind a third-party penetration test would produce. We surface structural risks (clones, blast radius, layer violations) — not exploit paths.
+- **Performance profiling**. Some findings touch hot paths (when runtime telemetry is wired), but this isn't a benchmark run.
+- **Code review of in-flight PRs.** This report covers *merged* history. For pre-merge gating, install the free CLI plus, when it ships, the Roam Review GitHub App.
+
+## Methodology
+
+Roam replays the current detector set against each commit's outgoing diff as if it were a PR — no historical re-indexing. Findings reflect what Roam catches today on those PRs, not what an earlier Roam version would have. The detector set is stable across Team (30 PRs) and Deep (90 PRs) windows.
+
+_Generated by `roam pr-replay --tier team` on 2026-07-07 22:13 UTC. Engine: `roam postmortem` walks the range; `roam critique` evaluates each diff. Both ship in the open-source CLI ([github.com/Cranot/roam-code](https://github.com/Cranot/roam-code))._

--- a/templates/audit-report/sample-pr-replay-roam-selfaudit.md
+++ b/templates/audit-report/sample-pr-replay-roam-selfaudit.md
@@ -1,7 +1,7 @@
 # PR Replay Report — Showcase — roam-code self-audit
 
-**Tier:** Team — 30 PRs  
-**Commit range:** `HEAD~30..HEAD`  
+**Tier:** Team  
+**Commit range:** `HEAD~30..HEAD` — 53 merged PRs replayed  
 **Generated:** 2026-07-07 22:11 UTC  
 **Tool:** `roam pr-replay` — `postmortem` + `critique` engine
 
@@ -18,7 +18,7 @@ the EU AI Act, or any other framework — the conformity assessment remains with
 ---
 
 
-Thirty most-recent merged PRs on the target branch, scored against the current Roam detector set. Includes founder review of the top findings on a 30-minute call.
+The most-recent merged PRs on the target branch in this commit range (53 replayed), scored against the current Roam detector set. Includes founder review of the top findings on a 30-minute call.
 
 > **Evidence framing.** PR Replay produces a structural-review report that **supports evidence for** governance review and **maps to** change-management controls. It does not certify compliance with SOC 2, ISO 42001, the EU AI Act, or any other framework; the control mapping and conformity assessment stay with the customer.
 

--- a/templates/audit-report/sample-pr-replay-roam-selfaudit.md
+++ b/templates/audit-report/sample-pr-replay-roam-selfaudit.md
@@ -1,0 +1,98 @@
+# PR Replay Report — Showcase — roam-code self-audit
+
+**Tier:** Team — 30 PRs  
+**Commit range:** `HEAD~30..HEAD`  
+**Generated:** 2026-07-07 22:11 UTC  
+**Tool:** `roam pr-replay` — `postmortem` + `critique` engine
+
+> **Real sample — roam-code auditing its own history.** This is an actual
+> `roam pr-replay --tier team` report on roam's own recent merged PRs — real
+> detectors, real SHAs, real findings, not synthetic data. Run
+> `roam pr-replay --tier sample` for a free self-serve preview on your own repo,
+> or email <hello@roam-code.com> to commission a paid Team or Deep engagement.
+
+This report **supports evidence for** structural-review governance and **maps to**
+change-management controls. It does not certify compliance with SOC 2, ISO 42001,
+the EU AI Act, or any other framework — the conformity assessment remains with the buyer.
+
+---
+
+
+Thirty most-recent merged PRs on the target branch, scored against the current Roam detector set. Includes founder review of the top findings on a 30-minute call.
+
+> **Evidence framing.** PR Replay produces a structural-review report that **supports evidence for** governance review and **maps to** change-management controls. It does not certify compliance with SOC 2, ISO 42001, the EU AI Act, or any other framework; the control mapping and conformity assessment stay with the customer.
+
+## Executive summary
+
+**Verdict:** 11 of 53 PRs (20%) would have surfaced findings — 0 review-eligible (high), 76 review-required (medium).
+
+- PRs replayed: **53**
+- PRs Roam would have flagged pre-merge: **11**
+- High-severity findings (would block CI): **0**
+- Medium-severity findings (would gate review): **76**
+
+## Evidence coverage
+
+PR Replay is a merged-history replay, not a continuous approval system. The companion evidence bundle answers all eight evidence questions fully or partially when `--evidence-bundle` is used; the buyer-facing coverage floor is:
+
+| Evidence question | PR Replay coverage |
+|---|---|
+| Who acted? | Out of scope for attribution; git metadata may appear only as source metadata. |
+| What authority existed? | Out of scope except for the replay mode used to produce this report. |
+| What context was read? | Partial: commit range, detector version, and local run context. |
+| What changed? | In scope: replay window and per-commit changed subjects. |
+| What could break? | In scope: detector findings, blast-radius signals, and severity. |
+| What policy applied? | In scope: current Roam detector set and any supplied rules. |
+| What verified it? | Partial: replay detectors only; no test execution is implied. |
+| Who accepted risk? | Out of scope unless GitHub approval data is attached explicitly. |
+
+## What Roam would have flagged
+
+| Detector | Total findings | PRs with this finding |
+|---|---:|---:|
+| `impact` | 13 | 3 / 53 |
+| `intent` | 8 | 8 / 53 |
+
+The highest-impact class on this window was **`impact`** (13 findings across 3 PRs). Wiring a CI gate against this class is the single highest-leverage move surfacing from this replay.
+
+## Per-PR breakdown
+
+Top 11 PRs ranked by severity (high → medium → total).
+
+| Date | SHA | Subject | High | Medium | Top hits |
+|---|---|---|---:|---:|---|
+| 2026-07-03 | `27efec7d` | chore: automated code-quality and release hygiene batch | 0 | 65 | impact x10 |
+| 2026-06-20 | `5652edba` | style: ruff format + autofix repo drift; fix orphaned return | 0 | 2 | impact x2 |
+| 2026-07-03 | `b9030bdf` | fix: satisfy pre-push quality gates | 0 | 1 | impact x1 |
+| 2026-06-20 | `aa263622` | fix: restore 4 more detectors autopilot falsely removed as g | 0 | 1 | intent x1 |
+| 2026-06-20 | `10630b7a` | fix: restore 7 detectors autopilot falsely removed as graph- | 0 | 1 | intent x1 |
+| 2026-06-19 | `295178c3` | review-security: Potential unsanitized taint flow: os.enviro | 0 | 1 | intent x1 |
+| 2026-06-19 | `635210c4` | backlog: broad `except Exception:` (codebase has 34 specific | 0 | 1 | intent x1 |
+| 2026-06-19 | `7123b60b` | review-security: Potential unsanitized taint flow: os.enviro | 0 | 1 | intent x1 |
+| 2026-06-19 | `c2df1caf` | backlog: broad `except Exception:` (codebase has 34 specific | 0 | 1 | intent x1 |
+| 2026-06-19 | `c7f22971` | backlog: broad `except Exception:` (codebase has 34 specific | 0 | 1 | intent x1 |
+| 2026-06-19 | `ca8c0cae` | review-security: Potential unsanitized taint flow: os.enviro | 0 | 1 | intent x1 |
+
+## Recommended next steps
+
+- **Wire CI gates against the top 2 detector class(es)** — `impact`, `intent`. `roam critique` returns exit code 5 on any high-severity finding, so a single CI step gates every PR. See <https://roam-code.com/docs/>.
+- **Run `roam preflight <symbol>` before changing high-blast-radius code.** The blast radius doesn't show up in the diff; it shows up in the graph.
+- **Add `roam clones --persist` to your indexing pipeline.** Then `roam critique` picks up clone-not-edited cases on every PR — the single most common AI-shaped bug across replays in similar codebases.
+- **Consider the Deep tier** if the patterns above warrant a 90-PR window, per-detector deep-dive, and a 90-minute walk-through with a written remediation plan: <https://roam-code.com/#audit>.
+
+## Apply this fee toward Roam Review
+
+50% of the engagement fee — **$1,250** — credits toward your first year of [Roam Review](https://roam-code.com/pricing) if you subscribe within **60 days** of report delivery. Roam Review runs the same detectors on every pull request automatically, with a sticky PR comment, BLOCK / REVIEW / APPROVE verdict, and exit-code-5 CI gating. Mention this report when subscribing and we apply the credit to the first invoice.
+
+## What this report does *not* cover
+
+- **Semantic correctness** — whether the code does the right thing. We complement semantic reviewers (CodeRabbit, Greptile, Qodo), we don't replace them.
+- **Security audit** of the kind a third-party penetration test would produce. We surface structural risks (clones, blast radius, layer violations) — not exploit paths.
+- **Performance profiling**. Some findings touch hot paths (when runtime telemetry is wired), but this isn't a benchmark run.
+- **Code review of in-flight PRs.** This report covers *merged* history. For pre-merge gating, install the free CLI plus, when it ships, the Roam Review GitHub App.
+
+## Methodology
+
+Roam replays the current detector set against each commit's outgoing diff as if it were a PR — no historical re-indexing. Findings reflect what Roam catches today on those PRs, not what an earlier Roam version would have. The detector set is stable across Team (30 PRs) and Deep (90 PRs) windows.
+
+_Generated by `roam pr-replay --tier team` on 2026-07-07 22:11 UTC. Engine: `roam postmortem` walks the range; `roam critique` evaluates each diff. Both ship in the open-source CLI ([github.com/Cranot/roam-code](https://github.com/Cranot/roam-code))._

--- a/templates/distribution/landing-page/audit.html
+++ b/templates/distribution/landing-page/audit.html
@@ -116,7 +116,7 @@
         an AI-assisted change.
       </p>
       <div class="hero-ctas">
-        <a class="btn-primary" href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-team.md">See the sample report</a>
+        <a class="btn-primary" href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">See a real sample report</a>
         <a class="btn-secondary" href="#tiers">See the tiers</a>
       </div>
       <p class="hero-trust-strip">
@@ -264,7 +264,7 @@
             ranking, recommended CI gates, written narrative, founder
             walk-through. <strong>$1,250 credits toward Roam Review</strong>
             if you subscribe within 60 days.
-            <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-team.md">See sample output</a>.
+            <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">See sample output</a>.
           </p>
           <!-- STRIPE_TEAM_LINK / PLACEHOLDER_TEAM: when the live Stripe
                Payment Link URL is ready, replace the primary button's
@@ -288,7 +288,7 @@
             CI gates, and a 90-minute walk-through call.
             <strong>$3,000 credits toward Roam Review</strong> if you
             subscribe within 60 days.
-            <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-team.md">See sample (Team format; Deep adds the deep-dive section)</a>.
+            <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">See sample (Team format; Deep adds the deep-dive section)</a>.
           </p>
           <!-- STRIPE_DEEP_LINK / PLACEHOLDER_DEEP: when the live Stripe
                Payment Link URL is ready, replace the primary button's
@@ -368,7 +368,7 @@
       </div>
       <p class="how-it-works-foot" style="margin-top: 24px;">
         Markdown + PDF. You can preview the Team-tier shape on
-        <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-team.md">GitHub</a>
+        <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">GitHub</a>
         before commissioning.
       </p>
     </div>

--- a/templates/distribution/landing-page/audit.html
+++ b/templates/distribution/landing-page/audit.html
@@ -40,8 +40,8 @@
     "description": "Roam replays the current detector set against a buyer's last 5, 30, or 90 merged PRs and ships a written structural-review report covering findings the detectors would have flagged pre-merge, an aggregated by-detector breakdown, and recommended CI gates.",
     "offers": [
       {"@type": "Offer", "name": "PR Replay — Sample (DIY)", "price": "0", "priceCurrency": "USD", "availability": "https://schema.org/InStock", "description": "5-PR self-serve sample, watermarked, no founder review."},
-      {"@type": "Offer", "name": "PR Replay — Team", "price": "2500", "priceCurrency": "USD", "availability": "https://schema.org/PreOrder", "description": "30-PR report, 30-min founder walk-through. 50% of fee credits toward a Roam Review subscription within 60 days."},
-      {"@type": "Offer", "name": "PR Replay — Deep", "price": "6000", "priceCurrency": "USD", "availability": "https://schema.org/PreOrder", "description": "90-PR report with per-detector deep-dive, 90-min founder walk-through, written 90-day remediation plan. 50% of fee credits toward a Roam Review subscription within 60 days."}
+      {"@type": "Offer", "name": "PR Replay — Team", "price": "2500", "priceCurrency": "USD", "availability": "https://schema.org/PreOrder", "description": "30-PR report, 30-min founder walk-through. 50% of fee is banked as a founding-customer credit toward Roam Review; the 60-day redemption window starts when Roam Review reaches general availability, not at report delivery."},
+      {"@type": "Offer", "name": "PR Replay — Deep", "price": "6000", "priceCurrency": "USD", "availability": "https://schema.org/PreOrder", "description": "90-PR report with per-detector deep-dive, 90-min founder walk-through, written 90-day remediation plan. 50% of fee is banked as a founding-customer credit toward Roam Review; the 60-day redemption window starts when Roam Review reaches general availability, not at report delivery."}
     ]
   }
   </script>
@@ -221,7 +221,8 @@
       <p class="how-it-works-foot">
         After delivery: temporary clone is deleted, the git ledger we kept
         of the engagement is yours on request, and the optional 50% credit
-        toward Roam Review activates if you subscribe within 60 days.
+        toward Roam Review is banked as a founding-customer credit — the
+        60-day redemption window starts when Roam Review ships, not now.
       </p>
     </div>
   </section>
@@ -262,8 +263,8 @@
             Thirty most-recent merged PRs scored against the current
             detector set. Aggregated detector-class breakdown, per-PR
             ranking, recommended CI gates, written narrative, founder
-            walk-through. <strong>$1,250 credits toward Roam Review</strong>
-            if you subscribe within 60 days.
+            walk-through. <strong>$1,250 banked toward Roam Review</strong>
+            — redeemable within 60 days of its launch, not before.
             <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">See sample output</a>.
           </p>
           <!-- STRIPE_TEAM_LINK / PLACEHOLDER_TEAM: when the live Stripe
@@ -286,8 +287,8 @@
             Everything in Team plus a per-detector deep-dive section, a
             written 90-day remediation plan against the highest-impact
             CI gates, and a 90-minute walk-through call.
-            <strong>$3,000 credits toward Roam Review</strong> if you
-            subscribe within 60 days.
+            <strong>$3,000 banked toward Roam Review</strong> — redeemable
+            within 60 days of its launch, not before.
             <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">See sample (Team format; Deep adds the deep-dive section)</a>.
           </p>
           <!-- STRIPE_DEEP_LINK / PLACEHOLDER_DEEP: when the live Stripe
@@ -445,8 +446,9 @@
     <div class="audit-upsell-inner">
       <h2>Apply this fee toward Roam Review</h2>
       <p class="lede">
-        Half of the engagement fee credits toward your first year of Roam
-        Review if you subscribe within 60 days of report delivery.
+        Half of the engagement fee is banked toward your first year of Roam
+        Review — the 60-day redemption window starts when Roam Review ships
+        (it's in development), so the credit can't expire before you can use it.
       </p>
       <table class="compare-table" style="max-width: 760px; margin: 24px auto 0;">
         <caption class="visually-hidden">Roam Review credit math by PR Replay tier and Roam Review subscription tier.</caption>

--- a/templates/distribution/landing-page/audit.html
+++ b/templates/distribution/landing-page/audit.html
@@ -63,7 +63,7 @@
     "@type": "FAQPage",
     "mainEntity": [
       {"@type": "Question", "name": "How do I get the report on a private repo without giving you direct access?", "acceptedAnswer": {"@type": "Answer", "text": "We offer two paths: (1) you grant us a read-only deploy key on a temporary clone we delete on completion, or (2) you run roam pr-replay locally and send us the JSON envelope plus the markdown — we add the founder review and ship the polished deliverable. Both paths sign the DPA and a one-page SOW."}},
-      {"@type": "Question", "name": "What if you find nothing material on my repo?", "acceptedAnswer": {"@type": "Answer", "text": "If a Team engagement surfaces zero findings worth wiring into CI, we'll either run it on a different range at no extra cost (if you want broader coverage) or refund 50% of the fee. The whole point is that you'd have shipped the same incidents knowing what Roam would have flagged — if you wouldn't have, the engagement underdelivered."}},
+      {"@type": "Question", "name": "What if the report is noise, or finds nothing material?", "acceptedAnswer": {"@type": "Answer", "text": "You never pay for noise. On the walk-through, any finding your team calls a false positive is struck and refunded pro-rata. If fewer than half the high/medium findings survive as worth acting on, that is a full refund. A Team engagement that surfaces zero material findings is a 100% refund, not 50%. The guarantee is on the usefulness of the findings, not just their count."}},
       {"@type": "Question", "name": "Can I share the report with my CTO, board, or auditor?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. The report is yours. You own the IP and can redistribute internally without restriction. External attribution is appreciated but not required."}},
       {"@type": "Question", "name": "Why this and not just running roam critique ourselves?", "acceptedAnswer": {"@type": "Answer", "text": "You can. The CLI is Apache 2.0 and free forever. The paid engagement adds: founder review of the patterns that matter for your codebase specifically, a ranked recommendation of which detector classes to wire into CI first, a polished narrative artefact you can hand to leadership or auditors, and a 30 or 90-minute walk-through call."}},
       {"@type": "Question", "name": "How fast is the turnaround?", "acceptedAnswer": {"@type": "Answer", "text": "Five business days from kickoff for Team, ten business days for Deep. Kickoff happens the day we receive payment confirmation and the agreed-on commit range or repo access. We'll usually move faster on small repos."}},
@@ -500,14 +500,14 @@
         </p>
       </details>
       <details>
-        <summary>What if you find nothing material on my repo?</summary>
+        <summary>What if the report is noise, or finds nothing material?</summary>
         <p>
-          If a Team engagement surfaces zero findings worth wiring into
-          CI, we'll either run it on a different range at no extra cost
-          (if you want broader coverage) or refund 50% of the fee. The
-          point is to know whether you'd have shipped the same incidents
-          knowing what Roam would have flagged — if you wouldn't have,
-          the engagement underdelivered and we own that.
+          You never pay for noise. On the walk-through, any finding your
+          team calls a false positive is struck and refunded pro-rata. If
+          fewer than half the high/medium findings survive as worth acting
+          on, that's a full refund. And if a Team engagement surfaces zero
+          material findings, that's a 100% refund — not 50%. The guarantee
+          is on the usefulness of the findings, not just their count.
         </p>
       </details>
       <details>

--- a/templates/distribution/landing-page/governance.html
+++ b/templates/distribution/landing-page/governance.html
@@ -241,7 +241,7 @@
         for the control map and wording-discipline rules, see
         <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/control-mapping-README.md">control-mapping-README.md</a>.
         The companion
-        <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-team.md">PR Replay sample</a>
+        <a href="https://github.com/Cranot/roam-code/blob/main/templates/audit-report/sample-pr-replay-roam-selfaudit.md">PR Replay sample</a>
         covers merged-history detector replay (no run ledger required).
         For a redacted draft on your repository, email
         <a href="mailto:hello@roam-code.com?subject=Governance%20Evidence%20Pack%20sample">hello@roam-code.com</a>.


### PR DESCRIPTION
## What
Re-integrates this session's DM-critical selling-surface work onto the canonical `main` (v13.6.1), rebuilt cleanly after the fork reconcile. Scoped tight: samples + landing-page honesty. (service-report + F1–F14 precision come as separate reviewed PRs.)

## Commits (atomic, each hook-passing)
- **Real PR-Replay samples**, regenerated on the current v13.6.1 tool (not stale): `sample-pr-replay-roam-selfaudit.md` (roam auditing itself) + `sample-pr-replay-fastapi.md` (gold-standard repo, low-noise). Both wording-guard clean.
- **Repoint sample links** on audit.html + governance.html: 5 links off the fabricated "Demo Buyer Inc" sample → the real self-audit report.
- **Quality-based refund guarantee**: any finding the buyer calls a false positive is struck + refunded pro-rata; <half surviving = full refund; zero-material = 100% (not 50%). Visible FAQ + JSON-LD.
- **Banked credit**: the 50% Review credit is banked until Roam Review GA (kills the vaporware-clock that started at delivery for a product still in dev). All 6 occurrences + JSON-LD.

## Safety / verification
- Built on a fresh branch off `origin/main` — **parity-gated**: 4678 → 4680 files (+2 samples), **zero deletions**, exactly 4 files changed. (This is the check that would have caught the earlier bad PR #59.)
- All 3 JSON-LD blocks validated. Every commit passed pre-commit hooks (count-sync, wording-guard, leak scan) + pre-push.
- No internal/strategy docs; no code paths touched.

## Notes
- The site still uses `mailto:` checkout (Stripe links pending) — unchanged here.
- Dependabot flags 3 pre-existing vulns on the default branch (not from this PR).