### PR TITLE
perf(startup): lazy __version__ (−94ms/import) + session/turn telemetry join key

### DIFF
--- a/src/roam/__init__.py
+++ b/src/roam/__init__.py
@@ -1,8 +1,28 @@
 """Roam: Codebase comprehension tool for AI coding assistants."""
 
-from importlib.metadata import PackageNotFoundError, version
+from __future__ import annotations
 
-try:
-    __version__ = version("roam-code")
-except PackageNotFoundError:
-    __version__ = "dev"
+__all__ = ["__version__"]
+
+
+def __getattr__(name: str) -> str:
+    """Resolve ``roam.__version__`` lazily (PEP 562).
+
+    ``importlib.metadata`` costs ~80 ms to import on Windows, and resolving the
+    installed package version at *module import* meant every ``import roam`` —
+    and therefore every ``roam`` CLI invocation, including the per-prompt
+    compile hook — paid that cost. The compile/hook hot path never reads the
+    version, so deferring it here removes ~87 ms from every interactive
+    prompt's process startup. The few call sites that DO need the version
+    (``roam --version``, SBOM/attest/supply-chain, index-bundle) resolve it on
+    first access, exactly as before — ``from roam import __version__`` still
+    works.
+    """
+    if name == "__version__":
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("roam-code")
+        except PackageNotFoundError:
+            return "dev"
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/roam/commands/cmd_compile_stats.py
+++ b/src/roam/commands/cmd_compile_stats.py
@@ -46,6 +46,8 @@ _ROW_SCHEMA: dict[str, str] = {
     "envelope_bytes": "serialized envelope size in bytes (-1 if serialization failed)",
     "compile_ms": "wall-clock compile latency in milliseconds",
     "agent_mode": "ROAM_AGENT_MODE env at compile time (compile/roam/vanilla/unknown)",
+    "session_id": "ROAM_SESSION_ID env — join key to the consumer-side turn ledger; '' when unset",
+    "turn_seq": "ROAM_TURN_SEQ env — optional per-session turn sequence to disambiguate multiple compiles; '' when unset",
     "compiler_fp": "compiler-code fingerprint — attributes telemetry shifts to compiler revisions",
     "injection_advice": "hook-channel injection advice for this procedure/task",
     "probe_timings_ms": "OPTIONAL — per-probe-section latency map; present only when L1 routing fired on a cache MISS (HIT rows omit it: the reused plan carries stale MISS timings)",

--- a/src/roam/commands/cmd_hooks.py
+++ b/src/roam/commands/cmd_hooks.py
@@ -526,6 +526,7 @@ Installed by `roam hooks claude --write`. FAIL-OPEN: any error prints
 nothing and exits 0 (a broken roam install must never block a turn).
 """
 import json
+import os
 import subprocess
 import sys
 
@@ -539,9 +540,17 @@ def main():
         prompt = (payload.get("prompt") or "").strip()
         if len(prompt) < _MIN_PROMPT_CHARS:
             return
+        # Forward Claude's session id so the compile telemetry row carries a
+        # join key to the session's downstream outcome. Fail-open: an absent id
+        # just leaves the key empty, never breaks the hook.
+        env = os.environ.copy()
+        session_id = str(payload.get("session_id") or "").strip()
+        if session_id:
+            env["ROAM_SESSION_ID"] = session_id
         proc = subprocess.run(
             ["roam", "--json", "compile", prompt],
             capture_output=True, text=True, timeout=_COMPILE_TIMEOUT_S,
+            env=env,
         )
         if proc.returncode != 0 or not proc.stdout.strip():
             return

--- a/src/roam/plan/compiler.py
+++ b/src/roam/plan/compiler.py
@@ -11646,6 +11646,17 @@ def _maybe_append_compile_telemetry(
         # Rows pre-dating this edit lack the field; `--by-mode` buckets them
         # as 'unknown'.
         "agent_mode": os.environ.get("ROAM_AGENT_MODE", "unknown"),
+        # 2026-07-15 — session/turn join key. The compile row records the
+        # envelope's section list but nothing about what the agent did with it;
+        # a consumer-side turn ledger records the outcome (tool calls, result,
+        # session id) but not the section list. Stamping the session id (and an
+        # optional per-turn sequence) here — from env, exactly like agent_mode —
+        # is the one missing field that makes the two joinable, so per-section
+        # value becomes measurable at fleet scale instead of from small replays.
+        # Hosts set ROAM_SESSION_ID; the Claude prompt-submit hook forwards the
+        # editor's session id. Empty string when unset.
+        "session_id": os.environ.get("ROAM_SESSION_ID", ""),
+        "turn_seq": os.environ.get("ROAM_TURN_SEQ", ""),
         # 2026-06-09 — stamp the compiler-code fingerprint so telemetry
         # shifts (routing distributions, L1 rate, latency) are attributable
         # to compiler revisions. Without this, a classifier change and a

--- a/tests/test_compile_stats_schema.py
+++ b/tests/test_compile_stats_schema.py
@@ -25,6 +25,8 @@ _EXPECTED_FIELDS = {
     "envelope_bytes",
     "compile_ms",
     "agent_mode",
+    "session_id",
+    "turn_seq",
     "compiler_fp",
     "injection_advice",
     "probe_timings_ms",

--- a/tests/test_evidence_v0.py
+++ b/tests/test_evidence_v0.py
@@ -882,10 +882,22 @@ def testresolve_roam_version_falls_back_when_version_is_empty(
     import roam
     from roam.evidence.change_evidence import resolve_roam_version
 
-    monkeypatch.setattr(roam, "__version__", "", raising=False)
+    # ``roam.__version__`` resolves lazily via a PEP 562 module ``__getattr__``.
+    # Do NOT ``monkeypatch.setattr(roam, "__version__", ...)`` here: because the
+    # lazy getattr makes ``getattr(roam, "__version__")`` succeed, monkeypatch
+    # saves the resolved value and RESTORES it as a *real* module attribute on
+    # teardown — leaking a real ``__version__`` that shadows the lazy resolver
+    # for every later test in the process. Patch the resolver itself instead.
+    def _returns(value):
+        def _getattr(name: str):
+            return value
+
+        return _getattr
+
+    monkeypatch.setattr(roam, "__getattr__", _returns(""))
     assert resolve_roam_version() == "unknown"
 
-    monkeypatch.setattr(roam, "__version__", None, raising=False)
+    monkeypatch.setattr(roam, "__getattr__", _returns(None))
     assert resolve_roam_version() == "unknown"
 
 

--- a/tests/test_evidence_v0.py
+++ b/tests/test_evidence_v0.py
@@ -852,28 +852,19 @@ def testresolve_roam_version_falls_back_on_metadata_failure(
     The helper must NOT propagate the exception - collection must keep
     running, and the sentinel ``"unknown"`` is the canonical fallback.
     """
-    import sys
-
     import roam
     from roam.evidence.change_evidence import resolve_roam_version
 
-    # Force ``from roam import __version__`` to raise during the helper's
-    # deferred import. Easiest reliable way: temporarily remove the
-    # attribute from the loaded ``roam`` module so the import-bound
-    # ``from roam import __version__`` inside the helper raises
-    # ``ImportError``.
-    saved = roam.__version__
-    monkeypatch.delattr(roam, "__version__")
-    try:
-        # Sanity: the helper's deferred ``from roam import __version__``
-        # must hit ``ImportError`` now.
-        assert "roam" in sys.modules
-        result = resolve_roam_version()
-        assert result == "unknown"
-    finally:
-        # ``monkeypatch.delattr`` already restores on test teardown, but
-        # also keep ``saved`` available for any post-yield consumer.
-        roam.__version__ = saved  # type: ignore[attr-defined]
+    # ``roam.__version__`` is resolved lazily via a PEP 562 module
+    # ``__getattr__`` (deferred so ``importlib.metadata`` is not paid on every
+    # ``import roam``). Simulate the version resolution failing by making that
+    # resolver raise ``ImportError`` — the helper's deferred
+    # ``from roam import __version__`` must translate it to ``"unknown"``.
+    def _raise_import_error(name: str) -> str:
+        raise ImportError(f"simulated version-resolution failure for {name!r}")
+
+    monkeypatch.setattr(roam, "__getattr__", _raise_import_error)
+    assert resolve_roam_version() == "unknown"
 
 
 def testresolve_roam_version_falls_back_when_version_is_empty(

--- a/tests/test_stale_refs.py
+++ b/tests/test_stale_refs.py
@@ -3305,12 +3305,15 @@ class TestStaleRefsLspDynamicVersion:
         import roam
         from roam.commands.cmd_lsp import _server_version
 
-        saved = roam.__version__
-        monkeypatch.delattr(roam, "__version__")
-        try:
-            assert _server_version() == "unknown"
-        finally:
-            roam.__version__ = saved  # type: ignore[attr-defined]
+        # roam.__version__ is resolved lazily via a PEP 562 module __getattr__
+        # (deferred so importlib.metadata is not paid on every import). Force the
+        # helper's deferred ``from roam import __version__`` to raise ImportError
+        # so its ``"unknown"`` fallback is exercised.
+        def _raise_import_error(name: str) -> str:
+            raise ImportError(f"simulated version-resolution failure for {name!r}")
+
+        monkeypatch.setattr(roam, "__getattr__", _raise_import_error)
+        assert _server_version() == "unknown"
 
 
 class TestFindBrokenLinksRecipeFollowups:


### PR DESCRIPTION
Two independent, low-risk improvements to the compile hot path.

**cold-2 — lazy `__version__` (PEP 562).** `roam/__init__.py` resolved the installed package version eagerly at import, so every `import roam` (and thus every CLI call, including the per-prompt compile hook) paid ~80–94ms importing `importlib.metadata`. The hot path never reads `__version__`; a clear-and-reimport test confirms nothing on it re-pulls the module. Measured: `import roam` **142→48ms** median.

**E0 — session/turn join key.** The compile telemetry row records the envelope's section list but nothing about the agent's downstream outcome; a consumer-side turn ledger records the outcome but not the sections — neither is joinable. Stamp `session_id`/`turn_seq` from env (like `agent_mode`) + forward the editor's session id from the prompt-submit hook. Additive, fail-open; schema doc + guard test in lockstep.

Both neutral-by-construction. Full prepush gate green (7/7); 355 version-consumer + 84 telemetry/hook tests pass.