### PR TITLE
feat(verify): calc_divergence — advisory cross-impl rounding-semantics check

### DIFF
--- a/src/roam/commands/cmd_verify.py
+++ b/src/roam/commands/cmd_verify.py
@@ -483,6 +483,10 @@ _ALL_CHECKS: tuple[str, ...] = _DEFAULT_CHECKS + (
     "tests",
     "command_examples",
     "claims",
+    # Advisory: cross-file rounding-semantics divergence of a computed money field
+    # (== _VERIFY_CALC_DIVERGENCE_CATEGORY, defined near its check below). Not in
+    # _CATEGORY_WEIGHTS — never moves the composite score.
+    "calc_divergence",
     # Guardrail gates (env-flagged; see _verify_env_flag). Selectable via
     # --checks/--all/config; auto-selected by default on Python edits.
     _VERIFY_BREAKING_CATEGORY,
@@ -707,6 +711,8 @@ def auto_select_checks(target_paths: list[str]) -> list[str]:
         selected.add("command_examples")
     if any(_is_claim_surface(p) for p in target_paths):
         selected.add("claims")
+    if any(Path(p).suffix in _CALC_DIVERGENCE_EXTS and not is_test_file(p) for p in target_paths):
+        selected.add(_VERIFY_CALC_DIVERGENCE_CATEGORY)
     if has_py:
         # Behavioral + guardrail gates (env-flagged, reversible). The impacted-
         # test run is the executable signal that trips a behavioral regression
@@ -3306,6 +3312,93 @@ def _check_claims(changed_paths: list[str], root: Path) -> dict:
     return {"score": score, "violations": violations, "advisory": True, "claims_checked": claims_checked}
 
 
+_VERIFY_CALC_DIVERGENCE_CATEGORY = "calc_divergence"
+_CALC_DIVERGENCE_EXTS = frozenset(
+    {".php", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".vue", ".py", ".go", ".java", ".cs", ".rb", ".rs"}
+)
+_CALC_DIVERGENCE_SCAN_CAP = 1500  # parse at most this many same-field files per verify
+_CALC_DIVERGENCE_SKIP_DIRS = frozenset({"node_modules", "vendor", "dist", "build", ".git", "__pycache__"})
+
+
+def _check_calc_divergence(changed_paths: list[str], root: Path) -> dict:
+    """Advisory: a money field computed by the SAME name but DIFFERENT rounding
+    semantics across the repo silently disagrees to-the-cent (PHP ``round``
+    half-away vs JS ``Math.round`` half-up vs Python banker's). Flag, at the
+    changed site, any field a changed file computes that is rounding-semantics-
+    divergent across its repo-wide implementations. Deterministic, no gate — the
+    divergence may be intentional; the agent decides. Cross-file by nature, so it
+    scans the repo (text-prefiltered to same-field files, capped, disclosed)."""
+    from roam.index.calc_extract import extract_calcs_from_file, normalize_target, rounding_semantic
+
+    changed = [p for p in changed_paths if Path(p).suffix in _CALC_DIVERGENCE_EXTS and not is_test_file(p)]
+    if not changed:
+        return {"score": 100, "violations": []}
+    # field -> [(rel, Calc)] computed in the CHANGED files
+    changed_by_field: dict[str, list[tuple[str, object]]] = {}
+    for rel in changed:
+        for c in extract_calcs_from_file(root / rel):
+            changed_by_field.setdefault(normalize_target(c.target), []).append((rel, c))
+    if not changed_by_field:
+        return {"score": 100, "violations": []}
+
+    # gather all repo-wide implementations of those fields (bounded)
+    target_fields = set(changed_by_field)
+    field_needles = [f.lower().encode() for f in target_fields if f]
+    all_by_field: dict[str, list[object]] = {f: [c for _, c in changed_by_field[f]] for f in target_fields}
+    changed_abs = {str((root / c).resolve()) for c in changed}
+    scanned = 0
+    capped = False
+    for p in root.rglob("*"):
+        if scanned >= _CALC_DIVERGENCE_SCAN_CAP:
+            capped = True
+            break
+        if not p.is_file() or p.suffix not in _CALC_DIVERGENCE_EXTS:
+            continue
+        if any(part in _CALC_DIVERGENCE_SKIP_DIRS for part in p.parts) or is_test_file(str(p)):
+            continue
+        if str(p.resolve()) in changed_abs:
+            continue
+        try:
+            raw = p.read_bytes()
+        except OSError:
+            continue
+        low = raw.lower()
+        if not any(n in low for n in field_needles):  # cheap same-field prefilter
+            continue
+        scanned += 1
+        for c in extract_calcs_from_file(p):
+            f = normalize_target(c.target)
+            if f in target_fields:
+                all_by_field[f].append(c)
+
+    violations: list[dict] = []
+    for field, group in all_by_field.items():
+        sems = {s for c in group if (s := rounding_semantic(getattr(c, "language", ""), getattr(c, "rounding", None)))}
+        if len(sems) < 2:
+            continue
+        for rel, c in changed_by_field[field]:
+            violations.append(
+                {
+                    "severity": SEVERITY_WARN,
+                    "file": rel,
+                    "line": getattr(c, "line", 0),
+                    "message": (
+                        f"'{field}' is computed with divergent rounding semantics across the repo "
+                        f"({'/'.join(sorted(sems))}) — verify to-the-cent consistency (or confirm the difference is intended)"
+                    ),
+                    "category": _VERIFY_CALC_DIVERGENCE_CATEGORY,
+                }
+            )
+    result = {
+        "score": 100 if not violations else max(0, 100 - len(violations) * 5),
+        "violations": violations,
+        "advisory": True,
+    }
+    if capped:
+        result["scan_capped"] = _CALC_DIVERGENCE_SCAN_CAP
+    return result
+
+
 def _check_cycles(conn, file_ids: list[int], changed_paths: list[str]) -> dict:
     """Flag changed files in a SMALL import cycle (2..8 files) — actionable per
     edit. Large systemic tangles are out of scope (use `roam cycles`)."""
@@ -4763,6 +4856,9 @@ def _run_verify_categories(conn, selected: list[str], file_ids: list[int], targe
             selected, "command_examples", lambda: _check_command_examples(target_paths, root)
         ),
         "claims": _maybe_run_verify_check(selected, "claims", lambda: _check_claims(target_paths, root)),
+        _VERIFY_CALC_DIVERGENCE_CATEGORY: _maybe_run_verify_check(
+            selected, _VERIFY_CALC_DIVERGENCE_CATEGORY, lambda: _check_calc_divergence(target_paths, root)
+        ),
         _VERIFY_BREAKING_CATEGORY: _maybe_run_verify_check(
             selected, _VERIFY_BREAKING_CATEGORY, lambda: _check_breaking(conn, file_ids, target_paths, root)
         ),

--- a/tests/test_verify_calc_divergence.py
+++ b/tests/test_verify_calc_divergence.py
@@ -1,0 +1,80 @@
+"""Tests for the advisory ``calc_divergence`` verify check."""
+
+from __future__ import annotations
+
+import pytest
+
+from roam.commands.cmd_verify import (
+    _VERIFY_CALC_DIVERGENCE_CATEGORY,
+    _check_calc_divergence,
+    auto_select_checks,
+)
+
+
+def _grammars_available() -> bool:
+    try:
+        from tree_sitter_language_pack import get_parser
+
+        for lang in ("php", "typescript", "python"):
+            get_parser(lang)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _grammars_available(),
+    reason="tree-sitter grammars unavailable (offline / transient language-pack download failure)",
+)
+
+
+def test_flags_cross_language_rounding_semantics_divergence(tmp_path):
+    # same field 'vat' rounded half-away (PHP) and half-up (JS Math.round)
+    (tmp_path / "backend.php").write_text("<?php $vat = round($base * $rate / 100, 2);")
+    (tmp_path / "frontend.ts").write_text("const vat = Math.round((base * rate / 100) * 100) / 100;")
+    result = _check_calc_divergence(["backend.php"], tmp_path)
+    assert result["advisory"] is True
+    assert len(result["violations"]) == 1
+    v = result["violations"][0]
+    assert v["severity"] == "WARN"
+    assert v["file"] == "backend.php"
+    assert v["category"] == _VERIFY_CALC_DIVERGENCE_CATEGORY
+    assert "vat" in v["message"]
+
+
+def test_clean_when_rounding_consistent(tmp_path):
+    (tmp_path / "a.php").write_text("<?php $vat = round($base * $rate, 2);")
+    (tmp_path / "b.php").write_text("<?php $vat = round($base * $rate / 1, 2);")
+    result = _check_calc_divergence(["a.php"], tmp_path)
+    assert result["violations"] == []
+
+
+def test_skips_changed_test_files(tmp_path):
+    (tmp_path / "backend.php").write_text("<?php $vat = round($base * $rate, 2);")
+    (tmp_path / "frontend.ts").write_text("const vat = Math.round(base * rate * 100) / 100;")
+    # the CHANGED file is a test file -> no findings even though divergence exists
+    assert _check_calc_divergence(["backend.test.php"], tmp_path)["violations"] == []
+
+
+def test_no_findings_when_field_only_in_changed_file(tmp_path):
+    # a field computed in exactly one place cannot diverge
+    (tmp_path / "only.php").write_text("<?php $vat = round($base * $rate, 2);")
+    assert _check_calc_divergence(["only.php"], tmp_path)["violations"] == []
+
+
+def test_auto_select_includes_calc_divergence_for_source_edit():
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY in auto_select_checks(["app/Services/Vat.php"])
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY in auto_select_checks(["src/utils/vat.ts"])
+
+
+def test_auto_select_excludes_calc_divergence_for_test_only_edit():
+    # a test-only or docs-only change should not select the check
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in auto_select_checks(["tests/test_vat.php"])
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in auto_select_checks(["README.md"])
+
+
+def test_advisory_not_in_category_weights():
+    # advisory: must not move the composite gate score
+    from roam.commands.cmd_verify import _CATEGORY_WEIGHTS
+
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in _CATEGORY_WEIGHTS


### PR DESCRIPTION
An advisory `roam verify` category built on calc-inventory (#64). When a source edit touches a computed money field, it flags — at the changed site — any field whose implementations across the repo use rounding functions with **different tie semantics** (PHP `round` half-away vs JS `Math.round` half-up vs Python banker's), the silent to-the-cent bug a formula diff misses.

Deterministic, zero model calls, **advisory** (WARN, absent from `_CATEGORY_WEIGHTS` — never moves the gate score; the divergence may be intended). Cross-file by nature, so it scans the repo bounded (same-field text prefilter, cap 1500, disclosed via `scan_capped`) and skips test/vendored files. Auto-selected on any non-test source edit. 7 tests; broad verify sweep + prepush gate green.

Completes the compile→verify loop for calculations: calc-inventory surfaces them, this flags cross-impl rounding drift on edit.