### PR TITLE
fix(verify): make calc_divergence opt-in (default OFF)

### DIFF
--- a/src/roam/commands/cmd_verify.py
+++ b/src/roam/commands/cmd_verify.py
@@ -711,7 +711,14 @@ def auto_select_checks(target_paths: list[str]) -> list[str]:
         selected.add("command_examples")
     if any(_is_claim_surface(p) for p in target_paths):
         selected.add("claims")
-    if any(Path(p).suffix in _CALC_DIVERGENCE_EXTS and not is_test_file(p) for p in target_paths):
+    # Opt-in (default OFF): the divergence check does a bounded repo-wide scan
+    # (~seconds on a large calc-heavy tree), so it stays OUT of the auto set —
+    # the no-arg Stop-hook gate is byte-identical to before. Enable per-repo with
+    # ROAM_VERIFY_CALC_DIVERGENCE=1, or run it explicitly via `--checks
+    # calc_divergence` / `--all` regardless of the flag.
+    if _verify_env_flag("ROAM_VERIFY_CALC_DIVERGENCE", False) and any(
+        Path(p).suffix in _CALC_DIVERGENCE_EXTS and not is_test_file(p) for p in target_paths
+    ):
         selected.add(_VERIFY_CALC_DIVERGENCE_CATEGORY)
     if has_py:
         # Behavioral + guardrail gates (env-flagged, reversible). The impacted-

--- a/tests/test_verify_calc_divergence.py
+++ b/tests/test_verify_calc_divergence.py
@@ -62,13 +62,21 @@ def test_no_findings_when_field_only_in_changed_file(tmp_path):
     assert _check_calc_divergence(["only.php"], tmp_path)["violations"] == []
 
 
-def test_auto_select_includes_calc_divergence_for_source_edit():
+def test_auto_select_opt_in_default_off(monkeypatch):
+    # default OFF: the ~seconds repo scan stays out of the auto set (Stop hook
+    # byte-identical to before). Not selected even on a calc-bearing source edit.
+    monkeypatch.delenv("ROAM_VERIFY_CALC_DIVERGENCE", raising=False)
+    assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in auto_select_checks(["app/Services/Vat.php"])
+
+
+def test_auto_select_opt_in_when_enabled(monkeypatch):
+    monkeypatch.setenv("ROAM_VERIFY_CALC_DIVERGENCE", "1")
     assert _VERIFY_CALC_DIVERGENCE_CATEGORY in auto_select_checks(["app/Services/Vat.php"])
     assert _VERIFY_CALC_DIVERGENCE_CATEGORY in auto_select_checks(["src/utils/vat.ts"])
 
 
-def test_auto_select_excludes_calc_divergence_for_test_only_edit():
-    # a test-only or docs-only change should not select the check
+def test_auto_select_excludes_test_only_edit_even_when_enabled(monkeypatch):
+    monkeypatch.setenv("ROAM_VERIFY_CALC_DIVERGENCE", "1")
     assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in auto_select_checks(["tests/test_vat.php"])
     assert _VERIFY_CALC_DIVERGENCE_CATEGORY not in auto_select_checks(["README.md"])
 


### PR DESCRIPTION
Fresh-eyes follow-up to #66. The `calc_divergence` advisory check was auto-selected on every calc-bearing source edit and does a bounded repo-wide scan (~6s on a large calc-heavy repo), silently slowing the Stop-hook verify loop — and it only detects **within-repo** divergence (cross-repo needs the standalone `calc-inventory --divergence` at a common parent). Expensive advisory checks belong OFF the auto set by default (roam's taint/tenant_scope convention). Gate auto-selection behind `ROAM_VERIFY_CALC_DIVERGENCE` (default off); still runnable via `--checks`/`--all`. Stop-hook gate byte-identical to before.