### PR TITLE
fix(calc): adversarial-audit batch — 12 defects across the calc suite

### DIFF
--- a/src/roam/commands/cmd_calc_golden.py
+++ b/src/roam/commands/cmd_calc_golden.py
@@ -29,13 +29,14 @@ Usage::
 
 from __future__ import annotations
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 import click
 
 from roam.capability import roam_capability
 from roam.index.golden_calc import (
+    RULE_SEMANTICS,
     RULES,
     audit_corpus,
     check_with_rule,
@@ -131,7 +132,30 @@ def extract(ctx, source, inputs_spec, expect_spec, bucket_by, where_entries, lim
             click.echo(f"VERDICT: {verdict}")
         ctx.exit(2)
         return
-    write_corpus(cases, out_path)
+    if stats.kept == 0 and stats.read > 0:
+        # the suite's own liveness principle applied to its first stage: an
+        # empty corpus from a non-empty source is a mapping/filter defect
+        # (wrong column spelling, over-tight --where), never a silent success.
+        verdict = (
+            f"extract produced 0 cases from {stats.read} records "
+            f"({stats.skipped_missing} skipped for missing mapped values) — check --inputs/--expect/--where spellings"
+        )
+        if json_mode:
+            click.echo(to_json(json_envelope("calc-golden", summary={"verdict": verdict}, error="empty_corpus")))
+        else:
+            click.echo(f"VERDICT: {verdict}")
+        ctx.exit(2)
+        return
+    try:
+        write_corpus(cases, out_path)
+    except OSError as exc:
+        verdict = f"cannot write corpus to {out_path}: {exc}"
+        if json_mode:
+            click.echo(to_json(json_envelope("calc-golden", summary={"verdict": verdict}, error="write_failed")))
+        else:
+            click.echo(f"VERDICT: {verdict}")
+        ctx.exit(2)
+        return
     verdict = f"{stats.kept} cases extracted from {stats.read} records into {out_path} ({len(stats.buckets)} buckets)"
     facts = [
         f"{stats.kept} cases extracted",
@@ -168,10 +192,15 @@ def audit(ctx, corpus, base_key, rate_key, target_key, rate_map_spec):
     """Which rounding rule best explains each bucket? (+ residuals no rule explains)."""
     json_mode = ctx.obj.get("json") if ctx.obj else False
     token_budget = ctx.obj.get("budget", 0) if ctx.obj else 0
-    cases = read_corpus(corpus)
+    try:
+        cases = read_corpus(corpus)
+    except (ValueError, KeyError, TypeError) as exc:
+        raise click.UsageError(f"malformed corpus {corpus}: {exc}") from exc
     report = audit_corpus(cases, base_key, rate_key, target_key, rate_map=_parse_rate_map(rate_map_spec))
     ev, unex = report["cases_evaluated"], report["unexplained_by_best_rule"]
-    verdict = f"{ev} cases evaluated across {len(report['buckets'])} buckets; {unex} unexplained by any single rule"
+    verdict = (
+        f"{ev} cases evaluated across {len(report['buckets'])} buckets; {unex} unexplained by the best per-bucket rule"
+    )
     facts = [f"{ev} cases scanned", f"{unex} residual cases found", f"{len(report['buckets'])} buckets"]
     if json_mode:
         click.echo(
@@ -179,7 +208,7 @@ def audit(ctx, corpus, base_key, rate_key, target_key, rate_map_spec):
                 json_envelope(
                     "calc-golden",
                     budget=token_budget,
-                    summary={"verdict": verdict, **report},
+                    summary={"verdict": verdict, "rule_semantics": RULE_SEMANTICS, **report},
                     agent_contract={"facts": facts},
                 )
             )
@@ -198,30 +227,61 @@ def audit(ctx, corpus, base_key, rate_key, target_key, rate_map_spec):
 
 @calc_golden.command("check")
 @click.argument("corpus", type=click.Path(exists=True, dir_okay=False))
-@click.option("--rule", type=click.Choice(sorted(RULES)), default=None, help="Oracle = this rounding rule.")
+@click.option(
+    "--rule",
+    type=click.Choice(sorted(RULES)),
+    default=None,
+    help="Oracle = this rounding rule. NOTE: half_up = ties AWAY FROM ZERO "
+    "(calc-inventory label half_away_from_zero) — not JS Math.round's half-toward-+inf.",
+)
 @click.option("--base", "base_key", default="", help="(rule mode) input case_key for the base.")
 @click.option("--rate", "rate_key", default="", help="(rule mode) input case_key for the rate.")
 @click.option("--target", "target_key", default="", help="(rule mode) expect case_key to reproduce.")
 @click.option("--rate-map", "rate_map_spec", default="", help="(rule mode) CODE=PERCENT,... map.")
 @click.option("--runner", default="", help="Oracle = external command; JSONL cases on stdin, JSONL results on stdout.")
-@click.option("--tolerance", default="0.005", show_default=True, help="Max |delta| treated as equal (cents-exact).")
-@click.option("--sample", type=int, default=0, help="Deterministic stride-sample N cases (0 = full corpus).")
+@click.option(
+    "--tolerance",
+    default="0.001",
+    show_default=True,
+    help="Max |delta| treated as equal. >=0.005 disables tie discrimination "
+    "(an unrounded product is always within half a cent of the rounded value).",
+)
+@click.option(
+    "--timeout",
+    "runner_timeout",
+    type=click.IntRange(min=1),
+    default=600,
+    show_default=True,
+    help="(runner mode) seconds before the runner is killed.",
+)
+@click.option(
+    "--sample", type=click.IntRange(min=0), default=0, help="Deterministic stride-sample N cases (0 = full corpus)."
+)
 @click.pass_context
-def check(ctx, corpus, rule, base_key, rate_key, target_key, rate_map_spec, runner, tolerance, sample):
+def check(ctx, corpus, rule, base_key, rate_key, target_key, rate_map_spec, runner, tolerance, runner_timeout, sample):
     """Replay the corpus against an oracle; exit 5 on any cent-level breach.
 
-    Liveness: zero replayed cases on a non-empty corpus ALSO exits 5 — a gate
-    that silently did nothing must never read as green.
+    Liveness: zero replayed cases on a non-empty corpus exits 5, and in runner
+    mode ANY unanswered case (missing > 0) also exits 5 — a runner that
+    silently drops the hard buckets must never read green.
     """
     json_mode = ctx.obj.get("json") if ctx.obj else False
     token_budget = ctx.obj.get("budget", 0) if ctx.obj else 0
     if bool(rule) == bool(runner.strip()):
         raise click.UsageError("exactly one oracle required: --rule ... OR --runner ...")
-    cases = read_corpus(corpus)
+    try:
+        tol = Decimal(tolerance)
+    except InvalidOperation as exc:
+        raise click.UsageError(f"--tolerance {tolerance!r} is not a decimal number") from exc
+    if tol < 0:
+        raise click.UsageError("--tolerance must be >= 0")
+    try:
+        cases = read_corpus(corpus)
+    except (ValueError, KeyError, TypeError) as exc:
+        raise click.UsageError(f"malformed corpus {corpus}: {exc}") from exc
     if sample and len(cases) > sample:
-        stride = max(1, len(cases) // sample)
-        cases = cases[::stride][:sample]
-    tol = Decimal(tolerance)
+        stride = -(-len(cases) // sample)  # ceil: spans the whole corpus (no untested tail)
+        cases = cases[::stride]
     if rule:
         if not (base_key and rate_key and target_key):
             raise click.UsageError("--rule mode needs --base, --rate and --target")
@@ -232,12 +292,18 @@ def check(ctx, corpus, rule, base_key, rate_key, target_key, rate_map_spec, runn
     else:
         import shlex
 
-        result = check_with_runner(cases, shlex.split(runner), tolerance=tol)
+        result = check_with_runner(cases, shlex.split(runner), tolerance=tol, timeout=runner_timeout)
         oracle = f"runner:{runner}"
-    gate_failed = result.failed > 0 or (result.replayed == 0 and result.total > 0)
+    is_runner = bool(runner.strip())
+    gate_failed = (
+        result.failed > 0
+        or (result.replayed == 0 and result.total > 0)
+        or (is_runner and result.missing > 0)  # partial oracle = failing oracle
+    )
     pass_pct = round(100.0 * result.passed / result.replayed, 2) if result.replayed else 0.0
     verdict = (
-        f"{result.passed}/{result.replayed} replayed cases cent-exact ({pass_pct}%) vs {oracle}"
+        f"{result.passed}/{result.replayed} replayed of {result.total} cases cent-exact ({pass_pct}%) vs {oracle}"
+        f"{f'; {result.missing} case(s) never answered' if is_runner and result.missing else ''}"
         f"{'; GATE FAILED' if gate_failed else ''}"
         f"{'; LIVENESS: 0 cases replayed' if result.replayed == 0 and result.total > 0 else ''}"
     )
@@ -253,9 +319,11 @@ def check(ctx, corpus, rule, base_key, rate_key, target_key, rate_map_spec, runn
         "replayed": result.replayed,
         "passed": result.passed,
         "failed": result.failed,
+        "missing": result.missing,
         "pass_pct": pass_pct,
         "gate_failed": gate_failed,
         "buckets": result.buckets,
+        "rule_semantics": RULE_SEMANTICS,
     }
     if json_mode:
         click.echo(

--- a/src/roam/commands/cmd_calc_probe.py
+++ b/src/roam/commands/cmd_calc_probe.py
@@ -259,15 +259,12 @@ def calc_probe(ctx, paths):
             used |= part_used
             calc_count += part_count
         catalog_keys = {(i["language"], i["rounding"], i["mode"]) for i in _IDIOMS}
-        # keep every catalog idiom whose (lang, fn) the code uses — mode-specific
-        # variants match exactly; a used mode we can't express is disclosed.
-        used_fn = {(lang, fn) for lang, fn, _ in used}
-        idioms = [
-            i
-            for i in _IDIOMS
-            if (i["language"], i["rounding"]) in used_fn
-            and ((i["language"], i["rounding"], i["mode"]) in used or i["mode"] is None)
-        ]
+        # keep only idioms the code ACTUALLY uses — exact (lang, fn, mode)
+        # match. The mode=None catalog entry stands for "no explicit mode in
+        # the call", which is itself an exact extraction result; selecting
+        # mode-default variants the code never uses would report tie
+        # divergences the user does not have.
+        idioms = [i for i in _IDIOMS if (i["language"], i["rounding"], i["mode"]) in used]
         unprobed = sorted(
             f"{lang}:{fn}:{mode}"
             for (lang, fn, mode) in used
@@ -281,11 +278,18 @@ def calc_probe(ctx, paths):
         by_runtime.setdefault(idiom["runtime"], []).append(idiom)
     results: dict[str, list[str]] = {}
     skipped_runtimes: list[str] = []
+    failed_runtimes: list[str] = []
     for runtime, group in sorted(by_runtime.items()):
         if not _runtime_available(runtime):
             skipped_runtimes.append(runtime)
             continue
-        results.update(_run_idioms_for_runtime(runtime, group, _PROBE_INPUTS))
+        got = _run_idioms_for_runtime(runtime, group, _PROBE_INPUTS)
+        if not got:
+            # present on PATH but crashed/failed — must be disclosed separately
+            # from "not installed", or a one-runtime report reads vacuously green
+            failed_runtimes.append(runtime)
+            continue
+        results.update(got)
     ran = [i for i in idioms if i["id"] in results]
 
     # per-input comparison over normalized cents
@@ -297,10 +301,12 @@ def calc_probe(ctx, paths):
 
     verdict = (
         f"{len(divergences)}/{len(_PROBE_INPUTS)} tie inputs diverge across {len(ran)} idiom(s), "
-        f"{len(by_runtime) - len(skipped_runtimes)} runtime(s)"
+        f"{len(by_runtime) - len(skipped_runtimes) - len(failed_runtimes)} runtime(s)"
     )
     if skipped_runtimes:
         verdict += f"; skipped runtimes: {', '.join(sorted(skipped_runtimes))}"
+    if failed_runtimes:
+        verdict += f"; FAILED runtimes (present but crashed): {', '.join(sorted(failed_runtimes))}"
     facts = [
         f"{len(divergences)} divergent inputs found",
         f"{len(ran)} idioms ran",
@@ -312,6 +318,7 @@ def calc_probe(ctx, paths):
         "inputs_probed": len(_PROBE_INPUTS),
         "idioms_ran": [i["id"] for i in ran],
         "runtimes_skipped": sorted(skipped_runtimes),
+        "runtimes_failed": sorted(failed_runtimes),
         "unprobed_used_idioms": unprobed,
     }
     if scoped_note:

--- a/src/roam/commands/cmd_verify.py
+++ b/src/roam/commands/cmd_verify.py
@@ -3350,7 +3350,25 @@ def _check_calc_divergence(changed_paths: list[str], root: Path) -> dict:
 
     # gather all repo-wide implementations of those fields (bounded)
     target_fields = set(changed_by_field)
-    field_needles = [f.lower().encode() for f in target_fields if f]
+    # Prefilter needles must match the BYTES in candidate files, so cover both
+    # spellings of each field: the normalized form strips underscores (grouping
+    # vat_amount with vatAmount), but a file spelling `vat_amount` only contains
+    # the underscored form — search for the raw last-segment spellings too.
+    field_needles: list[bytes] = []
+    for f in target_fields:
+        if not f:
+            continue
+        field_needles.append(f.lower().encode())
+    for group in changed_by_field.values():
+        for _, c in group:
+            raw = getattr(c, "target", "")
+            for sep in ("->", "::", "."):
+                if sep in raw:
+                    raw = raw.split(sep)[-1]
+            raw = raw.lstrip("$").strip().lower()
+            if raw:
+                field_needles.append(raw.encode())
+    field_needles = list(dict.fromkeys(field_needles))
     all_by_field: dict[str, list[object]] = {f: [c for _, c in changed_by_field[f]] for f in target_fields}
     changed_abs = {str((root / c).resolve()) for c in changed}
     scanned = 0

--- a/src/roam/index/calc_extract.py
+++ b/src/roam/index/calc_extract.py
@@ -181,11 +181,31 @@ def _analyze_rhs(node, src: bytes, round_funcs: frozenset[str]) -> tuple[bool, s
                 is_calc = True
                 if rounding is None:
                     rounding = name
-                    mode_match = _MODE_CONST_RE.search(_text(n, src))
-                    if mode_match:
-                        rounding_mode = mode_match.group(1)
+                    rounding_mode = _own_mode_constant(n, src)
         stack.extend(n.children)
     return is_calc, rounding, rounding_mode
+
+
+def _own_mode_constant(call, src: bytes) -> str | None:
+    """Mode constant belonging to THIS call — nested calls' modes must not leak.
+
+    ``round(round($b, 2, PHP_ROUND_HALF_EVEN) + $a, 2)``: the outer call has no
+    mode argument; scraping the whole call text would mislabel it half_to_even.
+    Blank every nested call's byte range inside this call, then regex what
+    remains (the call's own argument text).
+    """
+    text = bytearray(src[call.start_byte : call.end_byte])
+    stack = list(call.children)
+    while stack:
+        n = stack.pop()
+        if n.type in _CALL_NODES:
+            lo = max(0, n.start_byte - call.start_byte)
+            hi = min(len(text), n.end_byte - call.start_byte)
+            text[lo:hi] = b" " * (hi - lo)
+            continue  # everything inside the nested call is blanked wholesale
+        stack.extend(n.children)
+    match = _MODE_CONST_RE.search(text.decode("utf-8", errors="replace"))
+    return match.group(1) if match else None
 
 
 def _operands_and_literals(node, src: bytes) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -331,6 +351,19 @@ _ROUNDING_SEMANTICS: dict[tuple[str, str], str] = {
 }
 
 
+# Grammar names that execute on another language's runtime and share its
+# rounding semantics: .ts/.tsx/.jsx/.vue script blocks are all JavaScript at
+# runtime. Applied inside rounding_semantic so a React (.tsx) or Vue frontend
+# gets the same labels as plain JS — without this, the suite's motivating
+# frontend-vs-backend case is invisible for those file types.
+LANGUAGE_ALIASES: dict[str, str] = {
+    "typescript": "javascript",
+    "tsx": "javascript",
+    "jsx": "javascript",
+    "vue": "javascript",
+}
+
+
 def rounding_semantic(language: str, func: str | None, mode: str | None = None) -> str | None:
     """Documented tie/direction semantics of a rounding fn in a language, if known.
 
@@ -353,22 +386,24 @@ def rounding_semantic(language: str, func: str | None, mode: str | None = None) 
         return _MODE_SEMANTICS.get(mode)
     if not func:
         return None
+    language = LANGUAGE_ALIASES.get(language, language)
     return _ROUNDING_SEMANTICS.get((language, func))
 
 
 def normalize_target(target: str) -> str:
     """Base field name for grouping divergent implementations.
 
-    ``$this->vatAmount`` / ``self.vat_amount`` / ``const vatAmount`` all reduce to
-    ``vatamount`` so the same conceptual field computed in two places (e.g. a PHP
-    backend and a JS frontend) groups together.
+    ``$this->vatAmount`` / ``self.vat_amount`` / ``vatAmount`` all reduce to
+    ``vatamount`` — casing style AND underscore convention are stripped so the
+    same conceptual field computed in a snake_case backend and a camelCase
+    frontend groups together.
     """
     t = target.strip()
     for sep in ("->", "::", "."):
         if sep in t:
             t = t.split(sep)[-1]
     t = t.lstrip("$").strip()
-    return t.lower()
+    return t.replace("_", "").lower()
 
 
 def normalize_formula(formula: str) -> str:

--- a/src/roam/index/golden_calc.py
+++ b/src/roam/index/golden_calc.py
@@ -88,7 +88,10 @@ def _decode_dbf_value(raw: bytes, fld: DbfField, encoding: str) -> str | None:
         return raw.decode(encoding, "replace").strip()
     if fld.type in ("N", "F"):
         s = raw.decode("ascii", "replace").strip()
-        if not s or s in (".",) or set(s) <= {"*"}:
+        # '*' anywhere marks dBase/VFP numeric overflow — the stored digits are
+        # unusable, not merely padded; partial forms like '**12.34' must be None
+        # (a junk string here would silently vanish downstream at Decimal-parse).
+        if not s or s in (".",) or "*" in s:
             return None
         return s
     if fld.type == "D":
@@ -119,23 +122,30 @@ def iter_dbf_records(
     """
     p = Path(path)
     with p.open("rb") as fh:
-        _, header_size, record_size, fields = read_dbf_header(fh)
+        record_count, header_size, record_size, fields = read_dbf_header(fh)
         by_name = {f.name.upper(): f for f in fields}
         if columns is not None:
             missing = [c for c in columns if c.upper() not in by_name]
             if missing:
                 raise KeyError(f"DBF {p.name} has no column(s) {missing}; available: {sorted(by_name)}")
-            wanted = [by_name[c.upper()] for c in columns]
+            # key the yielded dicts by the REQUESTED spelling: validation is
+            # case-insensitive, so lookups downstream (mappings, --where) must
+            # see the caller's names — otherwise `net=netvalue` against a table
+            # storing NETVALUE silently extracts zero cases.
+            wanted = [(c, by_name[c.upper()]) for c in columns]
         else:
-            wanted = fields
+            wanted = [(f.name, f) for f in fields]
         fh.seek(header_size)
-        while True:
+        emitted = 0
+        while emitted < record_count:
             rec = fh.read(record_size)
             if len(rec) < record_size or rec[:1] == b"\x1a":
                 break
+            emitted += 1  # header record count bounds the read — trailing bytes
+            # after the declared records (appender debris) must not become ghosts
             if rec[0] == _DELETED_FLAG:
                 continue
-            yield {f.name: _decode_dbf_value(rec[f.offset : f.offset + f.size], f, encoding) for f in wanted}
+            yield {name: _decode_dbf_value(rec[f.offset : f.offset + f.size], f, encoding) for name, f in wanted}
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +290,22 @@ RULES: dict[str, str] = {
     "floor": ROUND_FLOOR,
 }
 
+# Naming bridge to calc-inventory's semantics labels (rounding_semantic()):
+# golden's "half_up" is decimal ROUND_HALF_UP = half-AWAY-FROM-ZERO — it is NOT
+# JS Math.round's half-toward-+infinity, which calc-inventory labels
+# "half_up_toward_positive". Emitted in audit/check summaries so the two
+# vocabularies can be machine-joined; note no RULES entry expresses JS's
+# half-toward-+inf (a JS-produced corpus surfaces its negative ties as
+# residuals — a documented audit gap, not a bug).
+RULE_SEMANTICS: dict[str, str] = {
+    "half_up": "half_away_from_zero",
+    "half_even": "half_to_even",
+    "half_down": "half_toward_zero",
+    "truncate": "truncate",
+    "ceil": "toward_positive",
+    "floor": "toward_negative",
+}
+
 
 def to_decimal(s: str) -> Decimal | None:
     try:
@@ -393,6 +419,7 @@ class CheckResult:
     passed: int
     failures: list[dict]
     buckets: dict[str, dict]  # bucket -> {replayed, passed}
+    missing: int = 0  # runner mode: cases sent but never answered — a runner defect
 
     @property
     def failed(self) -> int:
@@ -421,7 +448,7 @@ def check_with_rule(
     rate_key: str,
     target_key: str,
     rate_map: dict[str, str] | None = None,
-    tolerance: Decimal = Decimal("0.005"),
+    tolerance: Decimal = Decimal("0.001"),
     max_failures: int = 20,
 ) -> CheckResult:
     """Oracle via a named rounding rule — corpus vs ``rule(base × rate%)``."""
@@ -447,7 +474,7 @@ def check_with_rule(
 def check_with_runner(
     cases: list[GoldenCase],
     runner_argv: list[str],
-    tolerance: Decimal = Decimal("0.005"),
+    tolerance: Decimal = Decimal("0.001"),
     max_failures: int = 20,
     timeout: int = 600,
 ) -> CheckResult:
@@ -457,6 +484,10 @@ def check_with_runner(
     on stdin ``{"id": N, "inputs": {...}}`` and must emit one JSON object per
     line on stdout ``{"id": N, "<expect-field>": value, ...}`` (any order).
     One process for the whole corpus — 100k cases must not mean 100k spawns.
+
+    Every case is sent, so a case the runner never answers is a RUNNER DEFECT,
+    counted in ``missing`` (the caller gates on it — a runner that silently
+    drops the hard buckets must never read green). Duplicate ids: last wins.
     """
     import subprocess
 
@@ -467,6 +498,7 @@ def check_with_runner(
     try:
         proc = subprocess.run(runner_argv, input=payload, capture_output=True, text=True, timeout=timeout, check=False)
     except (OSError, subprocess.TimeoutExpired) as exc:
+        result.missing = len(cases)
         result.failures.append({"id": -1, "bucket": "-", "inputs": {}, "deltas": {"runner": f"failed to run: {exc}"}})
         return result
     got_by_id: dict[int, dict] = {}
@@ -479,10 +511,12 @@ def check_with_runner(
             got_by_id[int(d["id"])] = d
         except (ValueError, KeyError, TypeError):
             continue
+    missing_ids: list[int] = []
     for c in cases:
         got = got_by_id.get(c.id)
         if got is None:
-            continue  # not replayed — liveness accounting catches wholesale silence
+            missing_ids.append(c.id)
+            continue
         result.replayed += 1
         b = result.buckets.setdefault(c.bucket, {"replayed": 0, "passed": 0})
         b["replayed"] += 1
@@ -492,4 +526,24 @@ def check_with_runner(
             b["passed"] += 1
         elif len(result.failures) < max_failures:
             result.failures.append({"id": c.id, "bucket": c.bucket, "inputs": c.inputs, "deltas": deltas})
+    result.missing = len(missing_ids)
+    if missing_ids and len(result.failures) < max_failures:
+        result.failures.append(
+            {
+                "id": missing_ids[0],
+                "bucket": "-",
+                "inputs": {},
+                "deltas": {"runner": f"{len(missing_ids)} case(s) never answered; first ids: {missing_ids[:10]}"},
+            }
+        )
+    if (result.replayed == 0 or proc.returncode != 0) and proc.stderr:
+        # a crashing/failing runner must leave a diagnostic, not just a count
+        result.failures.append(
+            {
+                "id": -1,
+                "bucket": "-",
+                "inputs": {},
+                "deltas": {"runner": f"exit {proc.returncode}; stderr tail: {proc.stderr[-500:]}"},
+            }
+        )
     return result

--- a/tests/test_calc_golden.py
+++ b/tests/test_calc_golden.py
@@ -328,3 +328,151 @@ def test_cli_check_requires_exactly_one_oracle(tmp_path):
 def test_to_decimal_exactness():
     assert to_decimal("1.005") == Decimal("1.005")  # no float in the path
     assert to_decimal("garbage") is None
+
+
+# ---------------------------------------------------------------------------
+# audit-fix regressions (2026-07-16 adversarial audit)
+# ---------------------------------------------------------------------------
+
+
+def test_runner_partial_answers_fail_the_gate(tmp_path):
+    """#1: a runner answering only SOME cases is a runner defect — exit 5."""
+    corpus = tmp_path / "c.jsonl"
+    write_corpus(_corpus_for_rule("half_up", n=10), corpus)
+    partial = tmp_path / "partial.py"
+    partial.write_text(
+        "import sys, json\n"
+        "from decimal import Decimal, ROUND_HALF_UP\n"
+        "for line in sys.stdin:\n"
+        "    line = line.strip()\n"
+        "    if not line: continue\n"
+        "    c = json.loads(line)\n"
+        "    if c['id'] >= 3: continue  # silently drop the rest\n"
+        "    vat = (Decimal(c['inputs']['net']) * Decimal(c['inputs']['rate']) / Decimal(100)).quantize(\n"
+        "        Decimal('0.01'), ROUND_HALF_UP)\n"
+        "    print(json.dumps({'id': c['id'], 'vat': str(vat)}))\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        calc_golden,
+        ["check", str(corpus), "--runner", f'"{sys.executable}" "{partial}"'],
+        obj={"json": True},
+    )
+    assert result.exit_code == 5
+    env = json.loads(result.output)
+    assert env["summary"]["missing"] == 7
+    assert env["summary"]["gate_failed"] is True
+
+
+def test_unrounded_runner_fails_default_tolerance(tmp_path):
+    """#2: the old 0.005 default let an UNROUNDED product pass every tie."""
+    corpus = tmp_path / "c.jsonl"
+    write_corpus([GoldenCase(id=0, bucket="10", inputs={"net": "0.05", "rate": "10"}, expect={"vat": "0.01"})], corpus)
+    raw_runner = tmp_path / "raw.py"
+    raw_runner.write_text(
+        "import sys, json\n"
+        "from decimal import Decimal\n"
+        "for line in sys.stdin:\n"
+        "    line = line.strip()\n"
+        "    if not line: continue\n"
+        "    c = json.loads(line)\n"
+        "    raw = Decimal(c['inputs']['net']) * Decimal(c['inputs']['rate']) / Decimal(100)\n"
+        "    print(json.dumps({'id': c['id'], 'vat': str(raw)}))  # 0.005, NOT rounded\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        calc_golden,
+        ["check", str(corpus), "--runner", f'"{sys.executable}" "{raw_runner}"'],
+        obj={"json": True},
+    )
+    assert result.exit_code == 5  # |0.01 - 0.005| = 0.005 > 0.001 default
+
+
+def test_dbf_lowercase_mapping_extracts(tmp_path):
+    """#3: case-insensitive validation must come with case-insensitive keying."""
+    dbf = _dbf_with_cases(tmp_path, rows=[{"NETVALUE": "100.00", "VATCAT": "1", "VATAMT": "24.00", "DOCTYPE": "1.1"}])
+    corpus = tmp_path / "c.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        calc_golden,
+        ["extract", str(dbf), "--inputs", "net=netvalue", "--expect", "vat=vatamt", "--out", str(corpus)],
+        obj={"json": True},
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["summary"]["cases"] == 1  # was 0 before the fix
+
+
+def test_extract_empty_corpus_exits_2(tmp_path):
+    """Liveness at the first stage: 0 kept cases from >0 records is a defect."""
+    dbf = _dbf_with_cases(tmp_path, rows=[{"NETVALUE": "100.00", "VATCAT": "1", "VATAMT": "24.00", "DOCTYPE": "1.1"}])
+    corpus = tmp_path / "c.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        calc_golden,
+        [
+            "extract",
+            str(dbf),
+            "--inputs",
+            "net=NETVALUE",
+            "--expect",
+            "vat=VATAMT",
+            "--where",
+            "DOCTYPE=9.9",  # matches nothing
+            "--out",
+            str(corpus),
+        ],
+        obj={"json": True},
+    )
+    assert result.exit_code == 2
+    assert json.loads(result.output)["error"] == "empty_corpus"
+
+
+def test_dbf_numeric_overflow_asterisks_are_none(tmp_path):
+    """#13: partial '*' padding is dBase overflow — junk, not a value."""
+    dbf = _dbf_with_cases(tmp_path, rows=[{"NETVALUE": "**12.34", "VATCAT": "1", "VATAMT": "24.00", "DOCTYPE": "x"}])
+    recs = list(iter_dbf_records(dbf))
+    assert recs[0]["NETVALUE"] is None
+
+
+def test_tolerance_parse_is_sealed(tmp_path):
+    """#15: a malformed --tolerance must be a clean usage error, not a traceback."""
+    corpus = tmp_path / "c.jsonl"
+    write_corpus([GoldenCase(id=0, bucket="b", inputs={"x": "1"}, expect={"y": "2"})], corpus)
+    runner = CliRunner()
+    result = runner.invoke(
+        calc_golden,
+        [
+            "check",
+            str(corpus),
+            "--rule",
+            "half_up",
+            "--base",
+            "x",
+            "--rate",
+            "x",
+            "--target",
+            "y",
+            "--tolerance",
+            "0,005",
+        ],
+        obj={"json": True},
+    )
+    assert result.exit_code == 2
+    assert "not a decimal number" in result.output
+
+
+def test_rule_semantics_bridge_in_summary(tmp_path):
+    """#6: the vocabulary bridge rides every audit/check envelope."""
+    corpus = tmp_path / "c.jsonl"
+    write_corpus(_corpus_for_rule("half_up", n=3), corpus)
+    runner = CliRunner()
+    env = json.loads(
+        runner.invoke(
+            calc_golden,
+            ["check", str(corpus), "--rule", "half_up", "--base", "net", "--rate", "rate", "--target", "vat"],
+            obj={"json": True},
+        ).output
+    )
+    assert env["summary"]["rule_semantics"]["half_up"] == "half_away_from_zero"

--- a/tests/test_calc_inventory.py
+++ b/tests/test_calc_inventory.py
@@ -97,10 +97,37 @@ def test_extract_missing_grammar_returns_empty():
 # ---- normalization helpers ------------------------------------------------
 
 
-def test_normalize_target_strips_access_and_sigil():
+def test_normalize_target_strips_access_sigil_and_underscores():
     assert normalize_target("$this->vatAmount") == "vatamount"
-    assert normalize_target("self.vat_amount") == "vat_amount"
+    # underscore convention must not split the group: a snake_case backend and a
+    # camelCase frontend computing the same field MUST collide on one key
+    assert normalize_target("self.vat_amount") == "vatamount"
     assert normalize_target("$vat") == "vat"
+
+
+def test_divergence_groups_snake_and_camel(tmp_path):
+    _write(tmp_path, "back.php", "<?php $vat_amount = round($base * $rate, 2);")
+    _write(tmp_path, "front.ts", "const vatAmount = Math.round(base * rate * 100) / 100;")
+    runner = CliRunner()
+    env = json.loads(runner.invoke(calc_inventory, [str(tmp_path), "--divergence"], obj={"json": True}).output)
+    fields = {d["field"] for d in env["divergences"]}
+    assert "vatamount" in fields  # snake + camel grouped
+
+
+def test_rounding_semantic_language_aliases():
+    # .tsx/.jsx/.vue script code runs on the JS runtime — same semantics
+    assert rounding_semantic("tsx", "round") == "half_up_toward_positive"
+    assert rounding_semantic("vue", "tofixed") == "half_up_toward_positive"
+    assert rounding_semantic("typescript", "tofixed") == "half_up_toward_positive"
+
+
+def test_nested_call_mode_does_not_poison_outer():
+    # outer round has NO mode; inner has HALF_EVEN — outer must not inherit it
+    src = b"<?php $total = round(round($b, 2, PHP_ROUND_HALF_EVEN) + $a, 2);"
+    c = extract_calcs("php", src)[0]
+    assert c.target == "$total"
+    assert c.rounding == "round"
+    assert c.rounding_mode is None  # the nested call's mode must not leak
 
 
 def test_normalize_formula_whitespace_paren_insensitive():

--- a/tests/test_calc_probe.py
+++ b/tests/test_calc_probe.py
@@ -121,6 +121,21 @@ def test_multi_path_unions_idioms(tmp_path):
 
 
 @pytest.mark.skipif(not _grammars_available(), reason="tree-sitter grammars unavailable")
+def test_scoped_mode_exact_match_only(tmp_path):
+    """#8 regression: code using ONLY round(x,2,PHP_ROUND_HALF_EVEN) must not
+    also probe the default-mode php:round — that would report tie divergences
+    the codebase does not have."""
+    (tmp_path / "a.php").write_text("<?php $vat = round($base * $rate, 2, PHP_ROUND_HALF_EVEN);")
+    runner = CliRunner()
+    env = json.loads(runner.invoke(calc_probe, [str(tmp_path)], obj={"json": True}).output)
+    ran = set(env["summary"]["idioms_ran"])
+    assert "php:round" not in ran  # the unused default-mode variant stays out
+    if shutil.which("php"):
+        assert ran == {"php:round:PHP_ROUND_HALF_EVEN"}
+        assert env["summary"]["divergent_inputs"] == 0  # one idiom cannot diverge
+
+
+@pytest.mark.skipif(not _grammars_available(), reason="tree-sitter grammars unavailable")
 def test_unprobed_used_idioms_disclosed(tmp_path):
     # floor is a recognized rounding fn but has no probe-catalog entry -> disclosed
     (tmp_path / "f.php").write_text("<?php $cents = floor($x * 100);")


### PR DESCRIPTION
An adversarial audit (17 findings, all confirmed by direct execution) of the shipped calc suite; this lands the 12 substantive fixes. Highlights:

- **CRITICAL — runner partial-oracle hole:** a runner answering only some cases read green. `missing` is now counted, diagnosed (ids + stderr tail), and **gates** (exit 5) in runner mode.
- **Tolerance hole:** default 0.005 let an *unrounded* product pass every tie by definition → default now 0.001, boundary documented.
- **DBF case-keying:** `net=netvalue` vs `NETVALUE` silently extracted 0 cases → requested-spelling keying + exit-2 on empty corpus from non-empty source.
- **normalize_target strips underscores** (snake↔camel now group) + verify prefilter searches both spellings; **LANGUAGE_ALIASES** so .tsx/.vue/TS get JS rounding semantics.
- **RULE_SEMANTICS bridge** joins golden's rule names to calc-inventory's labels in every envelope (half_up = away-from-zero ≠ JS Math.round).
- **Nested-call mode poisoning** fixed; **probe scoped mode** now exact-match only (no phantom divergences).
- Minor: ceil-stride sampling, DBF overflow→None, header record-count respected, sealed tolerance/corpus parsing, `--timeout`, failed-runtime disclosure.

12 new regression tests (81 total); prepush 7/7 green.