### PR TITLE
perf(compile): edit-trim flag (S4) + impact probe cap (tail-1)

### DIFF
--- a/src/roam/plan/compiler.py
+++ b/src/roam/plan/compiler.py
@@ -240,13 +240,26 @@ def injection_advice(procedure: str, task: str | None) -> str:
     """Advise the prompt-injection channel (Claude Code UPS hook) whether the
     envelope is worth injecting for this task.
 
-    Returns ``"inject"`` or ``"skip_generation_task"``. Explicit
-    ``roam compile`` callers always get the full envelope either way — the
-    advice only gates the per-prompt auto-injection channel.
+    Returns ``"inject"`` or a ``"skip_*"`` value. Explicit ``roam compile``
+    callers always get the full envelope either way — the advice only gates the
+    per-prompt auto-injection channel (the hook honors any ``startswith("skip")``,
+    so a new skip value works with already-deployed hooks without redeployment).
     """
     if procedure == "synthesis_query" and task and _GENERATION_SKIP_RE.search(task):
         return "skip_generation_task"
+    # Opt-in (default OFF): the ENVELOPE-TOKEN economics measured stack_trace_fix
+    # as the one live edit-class leak (source slices ride context every turn while
+    # the file:line is already in the pasted trace). Gate it behind a flag rather
+    # than default-skip — the claude arm measured the OPPOSITE sign, so a
+    # default-on skip would regress that family; ship the lever, A/B per family.
+    if procedure == "stack_trace_fix" and _skip_edit_envelope_enabled():
+        return "skip_edit_task"
     return "inject"
+
+
+def _skip_edit_envelope_enabled() -> bool:
+    """Whether ROAM_SKIP_EDIT_ENVELOPE opts stack_trace_fix out of injection."""
+    return os.environ.get("ROAM_SKIP_EDIT_ENVELOPE", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 # W35a — stack-trace shape. Real user task: "fix this: ... File 'x.py',
@@ -2299,6 +2312,12 @@ _ROAM_INPROC_DENYLIST = frozenset(
         # probe `timeout=` is actually enforceable.
         "boundary",
         "path-coverage",
+        # tail-1 (2026-07-16): `impact` (structural_blast probe) is O(reverse-
+        # caller-graph); on a hot symbol it ran 14.7s live because the in-process
+        # CliRunner lock makes its 8s probe timeout unenforceable. Route through
+        # the killable subprocess so the cap is real → fast fallback instead of a
+        # multi-second stall. The W147 result cache still serves warm hits.
+        "impact",
     }
 )
 

--- a/tests/test_compile_injection_advice.py
+++ b/tests/test_compile_injection_advice.py
@@ -72,6 +72,37 @@ class TestInjectionAdvice:
         assert injection_advice("freeform_explore", "what calls open_db") == "inject"
 
 
+class TestStackTraceEditTrim:
+    """S4 edit-trim lever: stack_trace_fix injection is opt-in (default OFF) —
+    the file:line already rides the pasted trace, but the claude arm measured
+    the opposite sign, so the skip ships as a flag, never a default."""
+
+    def test_default_off_still_injects(self, monkeypatch):
+        monkeypatch.delenv("ROAM_SKIP_EDIT_ENVELOPE", raising=False)
+        assert injection_advice("stack_trace_fix", "fix this TypeError at foo.py:42") == "inject"
+
+    def test_flag_on_skips(self, monkeypatch):
+        monkeypatch.setenv("ROAM_SKIP_EDIT_ENVELOPE", "1")
+        assert injection_advice("stack_trace_fix", "fix this TypeError at foo.py:42") == "skip_edit_task"
+
+    def test_flag_only_affects_stack_trace_fix(self, monkeypatch):
+        monkeypatch.setenv("ROAM_SKIP_EDIT_ENVELOPE", "1")
+        # other procedures are untouched by this flag
+        assert injection_advice("structural_callers", "fix foo.py:42") == "inject"
+        assert injection_advice("synthesis_query", "propose a refactor") == "inject"
+
+    def test_skip_value_honored_by_deployed_hooks(self):
+        # deployed UPS hooks gate on startswith("skip"), so the new value works
+        # without redeployment — guard that the returned token keeps that prefix
+        import os
+
+        os.environ["ROAM_SKIP_EDIT_ENVELOPE"] = "on"
+        try:
+            assert injection_advice("stack_trace_fix", "x").startswith("skip")
+        finally:
+            del os.environ["ROAM_SKIP_EDIT_ENVELOPE"]
+
+
 class TestHookHonorsAdvice:
     def test_hook_script_injects_nothing_on_skip_advice(self, tmp_path, monkeypatch):
         """Run the installed hook script with a stubbed `roam` that returns a

--- a/tests/test_impact_inproc_denylist.py
+++ b/tests/test_impact_inproc_denylist.py
@@ -1,0 +1,33 @@
+"""tail-1: `impact` must route through the killable subprocess, not in-process.
+
+The structural_blast probe calls `roam impact <sym>` with an 8s budget. On the
+in-process CliRunner path that budget is UNENFORCEABLE — the global runner lock
+cannot be cancelled mid-scan (documented at compiler.py's _ROAM_INPROC_DENYLIST
+for `dead`/`boundary`/`path-coverage`). A hot-symbol impact ran 14.7s live. This
+guards that impact is denylisted so its cap becomes real (fast fallback instead
+of a multi-second stall); the W147 result cache still serves warm hits.
+"""
+
+from __future__ import annotations
+
+from roam.plan import compiler
+from roam.plan.compiler import _ROAM_INPROC_DENYLIST, _roam_invoke_inproc
+
+
+def test_impact_is_denylisted():
+    assert "impact" in _ROAM_INPROC_DENYLIST
+
+
+def test_impact_invoke_inproc_returns_none(monkeypatch):
+    # even with the in-process path enabled, impact must decline it (-> None ->
+    # caller falls back to the killable subprocess where timeout= is enforced)
+    monkeypatch.setattr(compiler, "_ROAM_INPROC_ENABLED", True, raising=False)
+    assert _roam_invoke_inproc(["impact", "some_symbol"], None) is None
+    # also when a leading global flag precedes the subcommand
+    assert _roam_invoke_inproc(["--json", "impact", "some_symbol"], None) is None
+
+
+def test_other_scan_denylist_unchanged():
+    # the existing O(repo) scans stay denylisted (no regression)
+    for cmd in ("dead", "boundary", "path-coverage", "compile"):
+        assert cmd in _ROAM_INPROC_DENYLIST


### PR DESCRIPTION
Two source-verified savings levers from the hardened build plan (Tranche 1).

- **S4 edit-trim (opt-in, default OFF):** `stack_trace_fix` was measured as the one live edit-class envelope leak (source slices ride context every turn while the file:line is already in the pasted trace). `injection_advice` returns `skip_edit_task` when `ROAM_SKIP_EDIT_ENVELOPE` is set. Flag-gated, not default — the claude arm measured the *opposite* sign. Honored by already-deployed hooks (they gate on `startswith('skip')`); measurable via the `injection_advice` telemetry field.
- **tail-1:** add `impact` to `_ROAM_INPROC_DENYLIST`. The structural_blast probe's 8s budget is unenforceable on the in-process CliRunner path (uncancellable global lock — same reason `dead`/`boundary`/`path-coverage` are denylisted); a hot-symbol impact ran 14.7s live. Subprocess routing makes the cap real; W147 cache still serves warm hits. Chosen over a second cache (which would regress the dirty-tree staleness fix).

15 tests; prepush 7/7 green.