### PR TITLE
feat(telemetry): agent-mode stamping — non-production rows out of the KPIs (ruler-1)

### DIFF
--- a/src/roam/commands/cmd_bench.py
+++ b/src/roam/commands/cmd_bench.py
@@ -68,13 +68,20 @@ def _build_prompt(condition: str, task: str, compile_out: str) -> str:
 
 def _compile_envelope(task: str, cwd: str) -> str:
     """Run `roam compile <task>` and return its text envelope."""
+    from roam.plan.agent_mode import ENV_VAR, MODE_BENCH
+
     try:
+        # stamp the child's telemetry row as bench (measurement integrity — these
+        # rows must not land in the production L1-rate/latency KPIs). Passed via
+        # an explicit env so it holds regardless of the parent's own mode.
+        env = {**os.environ, ENV_VAR: MODE_BENCH}
         proc = subprocess.run(
             ["roam", "compile", task, "--artifact", "auto"],
             capture_output=True,
             text=True,
             timeout=10,
             cwd=cwd,
+            env=env,
         )
         return proc.stdout
     except (OSError, subprocess.TimeoutExpired):

--- a/src/roam/commands/cmd_compile_stats.py
+++ b/src/roam/commands/cmd_compile_stats.py
@@ -244,6 +244,13 @@ def _top_cache_misses(rows: list[dict], limit: int = 10) -> list[dict]:
     help="W91 — show top tasks that miss the cache most often. Helpful for `roam compile-cache build --top-misses`.",
 )
 @click.option(
+    "--include-bench",
+    is_flag=True,
+    default=False,
+    help="Include non-production rows (bench/corpus/trace/envelope_diff/cache/test) in the KPI "
+    "aggregates. Default excludes them so L1-rate and latency reflect real traffic only.",
+)
+@click.option(
     "--by-mode",
     is_flag=True,
     default=False,
@@ -276,10 +283,13 @@ def compile_stats(
     by_procedure: bool,
     slow_probes: bool,
     top_misses: bool,
+    include_bench: bool,
     by_mode: bool,
     schema: bool,
 ) -> None:
     """Show distribution stats over the compile telemetry log."""
+    from roam.plan.agent_mode import is_non_production
+
     json_mode = ctx.obj.get("json") if ctx.obj else False
     # `--schema` is static documentation: short-circuit BEFORE reading any
     # telemetry so it works even with no `.roam/compile-runs.jsonl` present.
@@ -291,8 +301,18 @@ def compile_stats(
             for field, meaning in _ROW_SCHEMA.items():
                 click.echo(f"  {field:<18s} {meaning}")
         return
-    rows = _read_telemetry(root)
+    all_rows = _read_telemetry(root)
+    # KPI aggregates (summary L1-rate/latency, by-procedure, top-misses) use
+    # PRODUCTION rows only by default — bench/corpus/trace/diff/cache/test rows
+    # would skew every reported number. `--by-mode` keeps the full set (its job
+    # is to show the split). `unknown` rows stay in: historically they are a
+    # MIXED bucket (all pre-stamp rows), so dropping them would hide real
+    # traffic — disclosed below instead.
+    excluded = sum(1 for r in all_rows if is_non_production(r))
+    rows = all_rows if include_bench else [r for r in all_rows if not is_non_production(r)]
     summary = _summarize(rows)
+    if excluded and not include_bench:
+        summary["excluded_non_production_rows"] = excluded
     # W52 — per-procedure breakdown
     if by_procedure and rows:
         from collections import defaultdict
@@ -321,12 +341,14 @@ def compile_stats(
     # W5 — by-mode breakdown. Joins on the `agent_mode` field
     # added to telemetry rows when ROAM_AGENT_MODE env var is set at compile
     # time (the host platform sets this per call). Pre-W5 rows lack the field,
-    # so they bucket as 'unknown' — useful baseline.
-    if by_mode and rows:
+    # so they bucket as 'unknown' — useful baseline. This breakdown ALWAYS uses
+    # the full row set (its whole job is to show the production/non-prod split),
+    # regardless of the --include-bench KPI filter.
+    if by_mode and all_rows:
         from collections import defaultdict
 
         per_mode: dict = defaultdict(lambda: {"n": 0, "l1": 0, "ms_sum": 0.0, "envelope_bytes_sum": 0, "cache_hits": 0})
-        for r in rows:
+        for r in all_rows:
             mode = r.get("agent_mode") or "unknown"
             per_mode[mode]["n"] += 1
             if r.get("art_label") == "l1_probe":
@@ -400,6 +422,8 @@ def compile_stats(
     click.echo(f"first call:        {summary['first_ts']}")
     click.echo(f"last call:         {summary['last_ts']}")
     click.echo(f"total compile calls: {summary['row_count']}")
+    if excluded and not include_bench:
+        click.echo(f"  (excluded {excluded} non-production row(s) from KPIs; --include-bench to keep them)")
     click.echo("")
     click.echo("Artifact distribution:")
     for art, count in summary["artifact_distribution"].items():

--- a/src/roam/commands/cmd_compiler_corpus.py
+++ b/src/roam/commands/cmd_compiler_corpus.py
@@ -92,10 +92,12 @@ def _compile_one(prompt: str, cwd: str | None) -> dict:
     }
     t0 = time.perf_counter()
     try:
+        from roam.plan.agent_mode import MODE_CORPUS, agent_mode
         from roam.plan.compiler import compile_for_artifact, compile_plan
 
         plan = compile_plan(prompt, cwd)
-        envelope, label = compile_for_artifact(plan, cwd)
+        with agent_mode(MODE_CORPUS):  # stamp corpus-sweep rows out of the KPIs
+            envelope, label = compile_for_artifact(plan, cwd)
     except Exception as exc:  # noqa: BLE001 — capture so one bad prompt doesn't kill the run
         record["error"] = f"{type(exc).__name__}: {exc}"
         record["compile_ms"] = (time.perf_counter() - t0) * 1000

--- a/src/roam/commands/cmd_dispatch_trace.py
+++ b/src/roam/commands/cmd_dispatch_trace.py
@@ -224,12 +224,16 @@ def _normalize_task(task: str) -> str:
 
 
 def _read_telemetry_match(root: str, task: str) -> dict | None:
-    """Return the most recent telemetry row whose task_hash matches ``task``.
+    """Return the most recent PRODUCTION telemetry row matching ``task``.
 
     W43/W52/W58 instrumentation writes one row per `roam compile` call to
-    `.roam/compile-runs.jsonl`. If a row already exists for this exact
-    task we prefer it (production data, real probe timings).
+    `.roam/compile-runs.jsonl`. If a row already exists for this exact task we
+    prefer it (real probe timings). Non-production rows (bench/corpus/trace/
+    diff/cache/test — including this command's own past runs) are skipped: a
+    trace must not present a benchmark's probe timings as production data.
     """
+    from roam.plan.agent_mode import is_non_production
+
     log_path = Path(root) / ".roam" / "compile-runs.jsonl"
     if not log_path.exists():
         return None
@@ -247,7 +251,7 @@ def _read_telemetry_match(root: str, task: str) -> dict | None:
                     row = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if row.get("task_hash") == target:
+                if row.get("task_hash") == target and not is_non_production(row):
                     matches.append(row)
     except OSError:
         return None
@@ -397,8 +401,11 @@ def dispatch_trace(ctx: click.Context, prompt: str, root: str, counterfactual: b
         data_source = "telemetry"
     else:
         try:
+            from roam.plan.agent_mode import MODE_TRACE, agent_mode
+
             plan = compile_plan(prompt, cwd=cwd)
-            env, art_label = compile_for_artifact(plan, cwd=cwd)
+            with agent_mode(MODE_TRACE):  # stamp trace-tool rows out of the KPIs
+                env, art_label = compile_for_artifact(plan, cwd=cwd)
             plan_obj = (env or {}).get("plan") or {}
             prefetched = plan_obj.get("prefetched_facts") or {}
             prefetched_keys = sorted(k for k in prefetched if not k.endswith("_definition"))

--- a/src/roam/commands/cmd_envelope_diff.py
+++ b/src/roam/commands/cmd_envelope_diff.py
@@ -573,10 +573,12 @@ def _compile_envelope(task: str, cwd: str) -> dict:
     the ~200-500ms compile-pipeline import cost.
     """
     # Lazy import — `roam.plan.compiler` is heavy (~5800 lines + networkx).
+    from roam.plan.agent_mode import MODE_ENVELOPE_DIFF, agent_mode
     from roam.plan.compiler import compile_for_artifact, compile_plan
 
     plan = compile_plan(task, cwd=cwd)
-    env, label = compile_for_artifact(plan, cwd=cwd)
+    with agent_mode(MODE_ENVELOPE_DIFF):  # stamp diff-tool rows out of the KPIs
+        env, label = compile_for_artifact(plan, cwd=cwd)
     # dogfood fix: the inner artifact env (from
     # `compile_for_artifact`) carries only {plan, schema, schema_version};
     # it has NEITHER `summary.classifier_confidence` NOR

--- a/src/roam/commands/cmd_hooks.py
+++ b/src/roam/commands/cmd_hooks.py
@@ -547,6 +547,10 @@ def main():
         session_id = str(payload.get("session_id") or "").strip()
         if session_id:
             env["ROAM_SESSION_ID"] = session_id
+        # Stamp real hook traffic as 'hook' so it is distinguishable from the
+        # mixed 'unknown' bucket in compile-stats. setdefault, not assign: an
+        # explicit ROAM_AGENT_MODE (a policy mode the user set) is preserved.
+        env.setdefault("ROAM_AGENT_MODE", "hook")
         proc = subprocess.run(
             ["roam", "--json", "compile", prompt],
             capture_output=True, text=True, timeout=_COMPILE_TIMEOUT_S,

--- a/src/roam/plan/agent_mode.py
+++ b/src/roam/plan/agent_mode.py
@@ -1,0 +1,62 @@
+"""Agent-mode telemetry stamping (measurement integrity).
+
+Every compile writes a row to ``.roam/compile-runs.jsonl`` stamped with
+``agent_mode`` (``os.environ["ROAM_AGENT_MODE"]``). That field feeds the L1-rate
+and latency KPIs — so rows produced by benchmarks, corpus sweeps, diff tools,
+and the test battery must be *distinguishable* from real production traffic, or
+every reported number silently mixes them in.
+
+``ROAM_AGENT_MODE`` is dual-purpose: it is also the mode-**policy** signal, but
+policy only honors values in ``VALID_MODES`` (read_only/safe_edit/...), so a
+telemetry stamp like ``bench`` or ``test`` is inert to policy (exactly how the
+pre-existing ``compile_cache_build`` stamp coexists). This module centralizes
+the set/restore dance the cache-warmer hand-rolled, and names the non-production
+stamps in one place so the stats reader can exclude them by construction.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+
+ENV_VAR = "ROAM_AGENT_MODE"
+
+# Telemetry-only stamps (NOT mode-policy modes) marking a row as non-production.
+# The stats reader default-excludes these from KPI aggregates; --include-bench
+# (and --by-mode) still surface them.
+MODE_BENCH = "bench"  # roam bench-compile
+MODE_CORPUS = "corpus"  # roam compiler-corpus
+MODE_TRACE = "trace"  # roam dispatch-trace
+MODE_ENVELOPE_DIFF = "envelope_diff"  # roam envelope-diff
+MODE_CACHE_BUILD = "compile_cache_build"  # roam compile-cache build (pre-existing)
+MODE_TEST = "test"  # the pytest battery (conftest default)
+MODE_HOOK = "hook"  # UPS-hook production channel (real traffic, explicitly stamped)
+
+# Rows to drop from KPI aggregates (L1-rate, latency, top-misses) by default.
+# MODE_HOOK is production and is NOT here. 'unknown' stays in — historically it
+# is a MIXED bucket (all pre-stamp rows), so dropping it would hide real traffic;
+# the stats output discloses that caveat instead.
+NON_PRODUCTION_MODES = frozenset({MODE_BENCH, MODE_CORPUS, MODE_TRACE, MODE_ENVELOPE_DIFF, MODE_CACHE_BUILD, MODE_TEST})
+
+
+@contextlib.contextmanager
+def agent_mode(value: str):
+    """Temporarily stamp ``ROAM_AGENT_MODE`` for compiles in this block.
+
+    Restores the prior value (or unsets it) on exit — safe for the long-lived
+    MCP server and for nested/parallel command dispatch within one process.
+    """
+    prior = os.environ.get(ENV_VAR)
+    os.environ[ENV_VAR] = value
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop(ENV_VAR, None)
+        else:
+            os.environ[ENV_VAR] = prior
+
+
+def is_non_production(row: dict) -> bool:
+    """True when a telemetry row was produced by a non-production channel."""
+    return (row.get("agent_mode") or "unknown") in NON_PRODUCTION_MODES

--- a/tests/test_agent_mode_telemetry.py
+++ b/tests/test_agent_mode_telemetry.py
@@ -1,0 +1,103 @@
+"""ruler-1: non-production compile rows must not skew the production KPIs."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from click.testing import CliRunner
+
+from roam.commands.cmd_compile_stats import compile_stats
+from roam.plan.agent_mode import (
+    ENV_VAR,
+    MODE_BENCH,
+    MODE_HOOK,
+    NON_PRODUCTION_MODES,
+    agent_mode,
+    is_non_production,
+)
+
+
+def test_agent_mode_context_sets_and_restores():
+    os.environ.pop(ENV_VAR, None)
+    with agent_mode(MODE_BENCH):
+        assert os.environ[ENV_VAR] == MODE_BENCH
+    assert ENV_VAR not in os.environ  # restored to absent
+
+
+def test_agent_mode_context_restores_prior_value():
+    os.environ[ENV_VAR] = "read_only"
+    try:
+        with agent_mode(MODE_BENCH):
+            assert os.environ[ENV_VAR] == MODE_BENCH
+        assert os.environ[ENV_VAR] == "read_only"  # prior preserved
+    finally:
+        os.environ.pop(ENV_VAR, None)
+
+
+def test_non_production_classification():
+    assert is_non_production({"agent_mode": MODE_BENCH})
+    assert is_non_production({"agent_mode": "test"})
+    assert is_non_production({"agent_mode": "compile_cache_build"})
+    # production channels stay IN the KPIs
+    assert not is_non_production({"agent_mode": MODE_HOOK})
+    assert not is_non_production({"agent_mode": "read_only"})
+    assert not is_non_production({"agent_mode": "unknown"})  # mixed bucket, kept
+    assert not is_non_production({})  # missing -> unknown -> kept
+
+
+def test_hook_is_production():
+    assert MODE_HOOK not in NON_PRODUCTION_MODES
+
+
+def _write_telemetry(root, rows):
+    d = root / ".roam"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "compile-runs.jsonl").write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _row(mode, label="l1_probe", ms=100.0):
+    return {
+        "ts": "2026-07-16T00:00:00Z",
+        "task_hash": f"h{hash(mode) % 1000}",
+        "procedure": "freeform_explore",
+        "art_label": label,
+        "agent_mode": mode,
+        "compile_ms": ms,
+        "envelope_bytes": 1000,
+    }
+
+
+def test_stats_excludes_non_production_by_default(tmp_path):
+    # 2 production l1 rows + 8 bench NON-l1 rows: production L1-rate must read
+    # 100%, not 20%, because the bench rows are excluded from the KPI.
+    rows = [_row("hook", "l1_probe"), _row("read_only", "l1_probe")]
+    rows += [_row(MODE_BENCH, "full") for _ in range(8)]
+    _write_telemetry(tmp_path, rows)
+    runner = CliRunner()
+    result = runner.invoke(compile_stats, ["--root", str(tmp_path)], obj={"json": True})
+    assert result.exit_code == 0, result.output
+    env = json.loads(result.output)
+    assert env["summary"]["row_count"] == 2  # only production rows
+    assert env["summary"]["excluded_non_production_rows"] == 8
+
+
+def test_stats_include_bench_keeps_all(tmp_path):
+    rows = [_row("hook", "l1_probe")] + [_row(MODE_BENCH, "full") for _ in range(8)]
+    _write_telemetry(tmp_path, rows)
+    runner = CliRunner()
+    result = runner.invoke(compile_stats, ["--root", str(tmp_path), "--include-bench"], obj={"json": True})
+    env = json.loads(result.output)
+    assert env["summary"]["row_count"] == 9
+    assert "excluded_non_production_rows" not in env["summary"]
+
+
+def test_by_mode_shows_full_split_regardless(tmp_path):
+    rows = [_row("hook", "l1_probe")] + [_row(MODE_BENCH, "full") for _ in range(8)]
+    _write_telemetry(tmp_path, rows)
+    runner = CliRunner()
+    # even without --include-bench, --by-mode must show BOTH modes
+    result = runner.invoke(compile_stats, ["--root", str(tmp_path), "--by-mode"], obj={"json": True})
+    env = json.loads(result.output)
+    assert set(env["summary"]["by_mode"]) == {"hook", MODE_BENCH}
+    assert env["summary"]["by_mode"][MODE_BENCH]["n"] == 8

--- a/tests/test_l1_rate_floor.py
+++ b/tests/test_l1_rate_floor.py
@@ -33,6 +33,12 @@ def test_l1_rate_stays_above_floor(monkeypatch):
     if not corpus.exists() or not (root / ".roam" / "index.db").exists():
         pytest.skip("dogfood corpus/index absent (public CI)")
     monkeypatch.chdir(root)
+    # measurement integrity: this test runs 60 real compiles that append to the
+    # repo's own .roam/compile-runs.jsonl. Stamp them 'test' so they never land
+    # in the production L1-rate/latency KPIs (compile-stats default-excludes it).
+    from roam.plan.agent_mode import ENV_VAR, MODE_TEST
+
+    monkeypatch.setenv(ENV_VAR, MODE_TEST)
 
     from roam.plan.compiler import compile_for_artifact, compile_plan
 


### PR DESCRIPTION
Measurement integrity. Compile telemetry (`.roam/compile-runs.jsonl`) feeds the L1-rate and latency KPIs, but benchmarks, corpus sweeps, the diff tool, and the pytest battery wrote UNstamped (`unknown`) rows indistinguishable from real traffic — skewing every reported number.

New `src/roam/plan/agent_mode.py`: an `agent_mode(value)` context manager (DRYs the cache-warmer's hand-rolled set/restore), `NON_PRODUCTION_MODES`, `is_non_production()`. `ROAM_AGENT_MODE` is dual-purpose but policy only honors `VALID_MODES`, so a `bench`/`test` stamp is inert to policy (same as the pre-existing `compile_cache_build` stamp).

- **Writers stamped:** bench-compile (child env), compiler-corpus / dispatch-trace / envelope-diff (in-process), the floor test (60 compiles into the real repo), and the UPS hook stamps `hook` via setdefault (an explicit policy mode is preserved) so real traffic leaves the mixed `unknown` bucket.
- **Reader:** compile-stats default-**excludes** non-production rows from the KPI aggregates + discloses the count; `--include-bench` keeps them; `--by-mode` always shows the full split; dispatch-trace's fast-path refuses to serve a non-production row as production data. `unknown` stays IN (historically mixed — disclosed, not dropped).

12 tests; prepush 7/7 green.