### PR TITLE
fix(compile-stats): disclose all-non-production telemetry in human output

### DIFF
--- a/src/roam/commands/cmd_compile_stats.py
+++ b/src/roam/commands/cmd_compile_stats.py
@@ -413,9 +413,15 @@ def compile_stats(
         return
 
     if not rows:
-        click.echo("VERDICT: no telemetry yet")
-        click.echo(f"  (no .roam/compile-runs.jsonl under {root})")
-        click.echo("  Run `roam compile <task>` to populate the log.")
+        if excluded and not include_bench:
+            # the file EXISTS and has rows — they were all non-production. Say so
+            # rather than the misleading "no telemetry / no file" message.
+            click.echo("VERDICT: no production telemetry")
+            click.echo(f"  ({excluded} row(s) present, all non-production; --include-bench to include them)")
+        else:
+            click.echo("VERDICT: no telemetry yet")
+            click.echo(f"  (no .roam/compile-runs.jsonl under {root})")
+            click.echo("  Run `roam compile <task>` to populate the log.")
         return
 
     click.echo(f"VERDICT: {summary['verdict']}")

--- a/tests/test_agent_mode_telemetry.py
+++ b/tests/test_agent_mode_telemetry.py
@@ -92,6 +92,22 @@ def test_stats_include_bench_keeps_all(tmp_path):
     assert "excluded_non_production_rows" not in env["summary"]
 
 
+def test_all_non_production_discloses_in_human_output(tmp_path):
+    # fresh-eyes edge: a repo whose telemetry is 100% non-production must NOT
+    # print the misleading "no telemetry yet / no file" message — the file
+    # exists, the rows were filtered. Disclose that in the human path too.
+    _write_telemetry(tmp_path, [_row(MODE_BENCH, "full") for _ in range(5)])
+    runner = CliRunner()
+    human = runner.invoke(compile_stats, ["--root", str(tmp_path)], obj={"json": False})
+    assert human.exit_code == 0
+    assert "no production telemetry" in human.output
+    assert "all non-production" in human.output
+    assert "no .roam/compile-runs.jsonl" not in human.output  # the OLD wrong message
+    # and the JSON path still carries the machine-readable excluded count
+    js = json.loads(runner.invoke(compile_stats, ["--root", str(tmp_path)], obj={"json": True}).output)
+    assert js["summary"]["excluded_non_production_rows"] == 5
+
+
 def test_by_mode_shows_full_split_regardless(tmp_path):
     rows = [_row("hook", "l1_probe")] + [_row(MODE_BENCH, "full") for _ in range(8)]
     _write_telemetry(tmp_path, rows)


### PR DESCRIPTION
Fresh-eyes follow-up to #73. When a repo's telemetry is 100% non-production, the human path printed the misleading 'no telemetry yet / no .roam/compile-runs.jsonl' message — the file exists and has rows, they were just filtered from the KPIs, undercutting the disclosure the filter guarantees. Now distinguishes file-absent from all-filtered. JSON path already carried the machine-readable count. 1 test; prepush 7/7.