### PR TITLE
fix(calc-golden): emit both residual counters + reject multiple @index keys

### DIFF
--- a/src/roam/commands/cmd_calc_golden.py
+++ b/src/roam/commands/cmd_calc_golden.py
@@ -226,13 +226,17 @@ def audit(ctx, corpus, base_key, rate_key, target_key, rate_map_spec, gross_key)
     )
     ev = report["cases_evaluated"]
     unex_net = report["unexplained_by_best_rule"]
-    unex_fam = report["unexplained_by_families"]
+    unex_best_fam = report["unexplained_by_best_family"]
+    unex_union = report["unexplained_by_family_union"]
+    # Two honest residual counters: best-single is the conservative headline
+    # (one (family, mode) rule per bucket); the union is the loose bound the
+    # residual examples are gated on (no rule at all matches).
     verdict = (
         f"{ev} cases across {len(report['buckets'])} buckets; "
-        f"{unex_net} unexplained by net-family rules, {unex_fam} unexplained by ALL "
-        f"families [{', '.join(report['families_fitted'])}]"
+        f"{unex_net} unexplained by the best net rule, {unex_best_fam} by the best family rule, "
+        f"{unex_union} by NO family rule at all [{', '.join(report['families_fitted'])}]"
     )
-    facts = [f"{ev} cases scanned", f"{unex_fam} residual cases found", f"{len(report['buckets'])} buckets"]
+    facts = [f"{ev} cases scanned", f"{unex_union} residual cases found", f"{len(report['buckets'])} buckets"]
     if json_mode:
         click.echo(
             to_json(
@@ -248,7 +252,8 @@ def audit(ctx, corpus, base_key, rate_key, target_key, rate_map_spec, gross_key)
     click.echo(f"VERDICT: {verdict}")
     for b in report["buckets"]:
         click.echo(
-            f"\n  bucket {b['bucket']}: {b['cases']} cases — best {b['best_family']} ({b['best_family_match_pct']}%)"
+            f"\n  bucket {b['bucket']}: {b['cases']} cases — best {b['best_family']} "
+            f"({b['best_family_match_pct']}%), union of all rules {b['family_union_match_pct']}%"
         )
         for rule, pct in sorted(b["family_match_pct"].items(), key=lambda kv: -kv[1])[:6]:
             click.echo(f"    {rule:26s} {pct}%")

--- a/src/roam/index/golden_calc.py
+++ b/src/roam/index/golden_calc.py
@@ -297,6 +297,8 @@ def extract_cases(
     plain_bucket_keys: list[str] = []
     for b in bucket_by:
         if b.startswith("@index:"):
+            if era_keys:
+                raise ValueError(f"only one @index:N pseudo-key allowed; got {era_keys[0]!r} and {b!r}")
             try:
                 era_size = max(1, int(b.split(":", 1)[1]))
             except ValueError as exc:
@@ -503,7 +505,13 @@ def audit_corpus(
 
     Back-compat: ``rule_match_pct`` / ``best_rule`` / ``unexplained_by_best_rule``
     stay net-family-only (plain mode names). ``family_match_pct`` /
-    ``best_family`` / ``unexplained_by_families`` add the full family view.
+    ``best_family`` add the full family view, with TWO distinct residual
+    counters: ``unexplained_by_best_family`` (conservative — one (family, mode)
+    rule per bucket) and ``unexplained_by_family_union`` (loose — no rule at
+    all matches; the metric ``residual_examples`` is gated on). The union is
+    soft by construction: with a derived gross and 6 rounding modes, "some rule
+    matches" degenerates to roughly |error| <= ~1 cent, so headline claims
+    should quote the best-single number.
     """
     roles = role_keys or {"net": base_key}
     # (family, mode) rules whose base role is resolvable from this corpus
@@ -515,11 +523,13 @@ def audit_corpus(
     buckets_out: list[dict] = []
     total_evaluated = 0
     total_unexplained = 0  # by net-family best rule (back-compat)
-    total_unexplained_families = 0  # by best across ALL families
+    total_unexplained_best_family = 0  # by the best single (family, mode) per bucket
+    total_unexplained_union = 0  # by NO (family, mode) rule at all
     for bucket, group in sorted(by_bucket.items()):
         net_fits = {rule: 0 for rule in RULES}
         fam_fits = {f"{f.name}:{mode}": 0 for f in active_families for mode in RULES}
         evaluated = 0
+        union_explained = 0
         residuals: list[dict] = []
         for c in group:
             rate = resolve_rate(c, rate_key, rate_map)
@@ -540,7 +550,9 @@ def audit_corpus(
                     if fam.fn(fbase, rate, RULES[mode]) == expect:
                         fam_fits[f"{fam.name}:{mode}"] += 1
                         fam_explained = True
-            if not fam_explained and len(residuals) < residual_examples:
+            if fam_explained:
+                union_explained += 1
+            elif len(residuals) < residual_examples:
                 residuals.append(
                     {
                         "id": c.id,
@@ -568,17 +580,20 @@ def audit_corpus(
                 "family_match_pct": {r: round(100.0 * n / evaluated, 2) for r, n in fam_fits.items()}
                 if evaluated
                 else {},
+                "family_union_match_pct": round(100.0 * union_explained / evaluated, 2) if evaluated else 0.0,
                 "residual_examples": residuals,
             }
         )
         total_evaluated += evaluated
         total_unexplained += (evaluated - max(net_fits.values())) if evaluated else 0
-        total_unexplained_families += (evaluated - (max(fam_fits.values()) if fam_fits else 0)) if evaluated else 0
+        total_unexplained_best_family += (evaluated - (max(fam_fits.values()) if fam_fits else 0)) if evaluated else 0
+        total_unexplained_union += evaluated - union_explained
     return {
         "buckets": buckets_out,
         "cases_evaluated": total_evaluated,
         "unexplained_by_best_rule": total_unexplained,
-        "unexplained_by_families": total_unexplained_families,
+        "unexplained_by_best_family": total_unexplained_best_family,
+        "unexplained_by_family_union": total_unexplained_union,
         "families_fitted": [f.name for f in active_families],
     }
 

--- a/tests/test_calc_golden.py
+++ b/tests/test_calc_golden.py
@@ -442,6 +442,38 @@ def test_audit_families_recover_gross_path():
     assert gross_best >= net_best
 
 
+def test_era_bucketing_rejects_multiple_index_keys():
+    """PR-#76 review F2: two @index:N entries must be a loud error, not last-wins."""
+    rows = [{"NET": str(i), "CAT": "2", "VAT": "1"} for i in range(12)]
+    with pytest.raises(ValueError, match="only one @index:N"):
+        extract_cases(
+            _records(*rows),
+            case_map=parse_mapping("net=NET,rate=CAT"),
+            expect_map=parse_mapping("vat=VAT"),
+            bucket_by=["@index:5", "@index:7"],
+        )
+
+
+def test_audit_best_family_vs_union_counters_distinct():
+    """PR-#76 review F1: best-single and union residual counters are BOTH emitted
+    and diverge when different cases are explained by different rules."""
+    # 10 half_up cases + 10 truncate cases in ONE bucket: each rule explains its
+    # half (plus tie-free overlap), the union explains all, best-single does not.
+    cases = []
+    for i, rule in enumerate(["half_up"] * 10 + ["truncate"] * 10):
+        net = Decimal(_TIE_NETS[i % len(_TIE_NETS)])
+        vat = predict(rule, net, Decimal("10"))
+        cases.append(GoldenCase(id=i, bucket="10", inputs={"net": str(net), "rate": "10"}, expect={"vat": str(vat)}))
+    report = audit_corpus(cases, "net", "rate", "vat")
+    assert report["unexplained_by_family_union"] == 0  # every case fits SOME rule
+    assert report["unexplained_by_best_family"] > 0  # no single rule fits all
+    b = report["buckets"][0]
+    assert b["family_union_match_pct"] == 100.0
+    assert b["best_family_match_pct"] < 100.0
+    # residual examples are gated on the union metric — none here
+    assert b["residual_examples"] == []
+
+
 def test_audit_backward_compat_net_only():
     # without gross role, audit stays net-family (v1 keys intact)
     cases = _corpus_for_rule("half_up", n=10)


### PR DESCRIPTION
Follow-up to #76, which merged verbatim before the two defects flagged in the verification comment were addressed:

1. **Metric/wording mismatch.** The audit verdict printed "N unexplained by ALL families" while the counter was per-bucket best-single-family, and `residual_examples` were gated on the (much looser) union. At era-3 shape this reports ~26% unexplained while only ever listing the ~1.7% union residuals. Now emits BOTH counters — `unexplained_by_best_family` (conservative headline) and `unexplained_by_family_union` (what the examples gate on) plus per-bucket `family_union_match_pct` — and the verdict says which is which. The docstring documents why the union is soft (derived gross + 6 modes ≈ |error| ≤ ~1 cent).

2. **Multiple `@index:N` entries silently last-wins** (verified: `[@index:5, @index:7]` → 12 rows bucketed `{era0: 7, era1: 5}`). Now a loud ValueError.

Both defects were CONFIRMED on the full 914,636-case INVO_HB run (see #76 comments). 2 new regression tests; 32/32 pass; prepush gates green.