### PR TITLE
fix(hooks): make the T2c heal actually heal — seed registry + content-verified states

### DIFF
--- a/scripts/seed_hook_body_shas.py
+++ b/scripts/seed_hook_body_shas.py
@@ -1,0 +1,109 @@
+"""Regenerate the _KNOWN_HOOK_BODY_SHAS seed block in cmd_hooks.py.
+
+Enumerates every hook body roam ever shipped (per the git history of
+src/roam/commands/cmd_hooks.py), computes the SHA-256 of each body in its
+DEPLOYED form — the raw literal for pre-stamp commits, the version-stamped
+form after — plus the deterministic variant compile-code's mode-override
+surgery produces (_override_hook_maintenance_commands, copied verbatim
+below). Run after ANY hook-body change and paste the output into the
+frozenset; the paired registry test fails when this drifts.
+
+Usage: python scripts/seed_hook_body_shas.py
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FILE = "src/roam/commands/cmd_hooks.py"
+NAMES = {"_CLAUDE_UPS_HOOK_SCRIPT": "ups", "_CLAUDE_STOP_HOOK_SCRIPT": "stop"}
+
+
+def surgered(script: str) -> str:
+    """compile-code's hook surgery, copied verbatim (cli.py, compile-code repo).
+
+    Duplicated as DATA-GENERATION logic only — roam must not import
+    compile-code. If compile-code changes its transform, rerun this script;
+    until then surgered bodies of the new shape classify "modified"
+    (report-only), never overwritten.
+    """
+    dynamic_command = '["roam", "--json", *args]'
+    overridden_dynamic_command = (
+        '["roam", *(["--override-mode"] if args and args[0] in {"verify", "index"} else []), "--json", *args]'
+    )
+    script = script.replace(dynamic_command, overridden_dynamic_command)
+    return re.sub(
+        r'(["\']roam["\']\s*,\s*)(["\'])(verify|index)\2',
+        r'\1"--override-mode", \2\3\2',
+        script,
+    )
+
+
+def git(*args: str) -> str:
+    return subprocess.run(["git", "-C", str(REPO), *args], capture_output=True, text=True, check=True).stdout
+
+
+def bodies_at(commit: str) -> dict[str, str] | None:
+    """Deployed-form hook bodies at a commit, or None if unparseable."""
+    try:
+        src = git("show", f"{commit}:{FILE}")
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None
+    out: dict[str, str] = {}
+    version = None
+    marker = "# roam-hook-version:"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+            if name in NAMES and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                out[NAMES[name]] = node.value.value
+            if name == "_HOOK_BODY_VERSION" and isinstance(node.value, ast.Constant):
+                version = node.value.value
+            if name == "_HOOK_VERSION_MARKER" and isinstance(node.value, ast.Constant):
+                marker = node.value.value
+    if not out:
+        return None
+    if version is not None:  # post-stamp commit: deployed form carries the marker
+        for k, body in out.items():
+            lines = body.split("\n", 1)
+            rest = lines[1] if len(lines) > 1 else ""
+            out[k] = f"{lines[0]}\n{marker} {version}\n{rest}"
+        out["_version"] = str(version)
+    return out
+
+
+def main() -> int:
+    commits = git("log", "--format=%H %cs", "--follow", "--", FILE).splitlines()
+    seen: dict[str, str] = {}  # sha -> provenance
+    for line in commits:
+        commit, date = line.split()
+        found = bodies_at(commit)
+        if not found:
+            continue
+        ver = found.pop("_version", "pre-stamp")
+        for kind, body in found.items():
+            for variant, text in (("pristine", body), ("surgered", surgered(body))):
+                if variant == "surgered" and text == body:
+                    continue  # surgery is a no-op on this body
+                sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+                if sha not in seen:
+                    label = f"v{ver}" if ver != "pre-stamp" else "pre-stamp"
+                    seen[sha] = f"{kind} {label} {variant} ({date} {commit[:8]})"
+    print(f"# {len(seen)} distinct deployed hook bodies across history")
+    for sha, prov in sorted(seen.items(), key=lambda kv: kv[1]):
+        print(f'        "{sha}",  # {prov}')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/roam/commands/cmd_doctor.py
+++ b/src/roam/commands/cmd_doctor.py
@@ -1843,8 +1843,67 @@ def _check_ci_workflow_drift() -> dict:
 # A failure here means "something to be aware of" rather than "roam is
 # broken." CI can still pass with advisory failures unless ``--strict``
 # is set. See cmd_doctor docstring for the full exit-code matrix.
+def _check_claude_hook_bodies() -> dict:
+    """Deployed Claude hook bodies are roam-shipped and current (advisory).
+
+    Covers both install levels. Flags: stale roam bodies (healable), bodies
+    whose settings entry is wired but whose file vanished, and modified /
+    foreign / unreadable bodies (need --force). The T2c spec routes this
+    reporting through doctor so a drifted fleet shows up in onboarding
+    diagnostics, not only when someone happens to run `hooks claude`.
+    """
+    from roam.commands.cmd_hooks import (
+        _CLAUDE_STOP_HOOK_FILENAME,
+        _CLAUDE_STOP_HOOK_SCRIPT,
+        _CLAUDE_UPS_HOOK_FILENAME,
+        _CLAUDE_UPS_HOOK_SCRIPT,
+        _claude_hook_dir,
+        _claude_settings_path,
+        _hook_entry_present,
+        _load_claude_settings,
+        _scan_hook_bodies,
+    )
+
+    managed = [
+        ("UserPromptSubmit", _CLAUDE_UPS_HOOK_FILENAME, _CLAUDE_UPS_HOOK_SCRIPT),
+        ("Stop", _CLAUDE_STOP_HOOK_FILENAME, _CLAUDE_STOP_HOOK_SCRIPT),
+    ]
+    problems: list[str] = []
+    scanned = 0
+    for level, user_level in (("project", False), ("user", True)):
+        settings, load_error = _load_claude_settings(_claude_settings_path(user_level))
+        if load_error:
+            continue  # unparseable settings are `hooks claude`'s exit-1 case, not ours
+        states = _scan_hook_bodies(_claude_hook_dir(user_level), managed)
+        for event, fname, _script in managed:
+            state = states.get(fname)
+            entry = _hook_entry_present(settings, event, fname)
+            if state == "missing":
+                if entry:
+                    problems.append(f"{level}:{fname}=missing (entry wired, body gone)")
+                continue
+            if state is None:
+                continue
+            scanned += 1
+            if state != "current":
+                problems.append(f"{level}:{fname}={state}")
+    if not problems:
+        detail = f"{scanned} deployed hook body(ies) current" if scanned else "no Claude hook bodies deployed"
+        return {"name": "Claude hook bodies", "passed": True, "detail": detail}
+    return {
+        "name": "Claude hook bodies",
+        "passed": False,
+        "detail": (
+            f"{len(problems)} hook body issue(s): "
+            + ", ".join(problems)
+            + " — `roam hooks claude --write` heals roam-shipped bodies; --force overwrites modified ones (.bak kept)"
+        ),
+    }
+
+
 _ADVISORY_CHECK_NAMES = frozenset(
     {
+        "Claude hook bodies",  # T2c heal reporting — actionable locally only
         "Optional extras",  # graceful degradation when extras missing
         "Cloud sync",  # OneDrive/Dropbox warning, not a hard break
         "MCP backpressure",  # only matters for MCP server users
@@ -1994,6 +2053,7 @@ def doctor(ctx, strict, persist):
     _run_check("optional_extras", _check_optional_extras)
     _run_check("cloud_sync", _check_cloud_sync)
     _run_check("cache_permissions", _check_cache_permissions)
+    _run_check("claude_hook_bodies", _check_claude_hook_bodies)
     _run_check("command_registry", _check_command_registry)
     _run_check("mcp_registry", _check_mcp_registry)
     _run_check("mcp_backpressure", _check_mcp_backpressure)

--- a/src/roam/commands/cmd_hooks.py
+++ b/src/roam/commands/cmd_hooks.py
@@ -12,6 +12,7 @@ W1148 audit memo.
 from __future__ import annotations
 
 import json
+import os
 import stat
 import subprocess
 import sys
@@ -1114,12 +1115,32 @@ _CLAUDE_UPS_HOOK_SCRIPT = _with_version_stamp(_CLAUDE_UPS_HOOK_SCRIPT)
 _CLAUDE_STOP_HOOK_SCRIPT = _with_version_stamp(_CLAUDE_STOP_HOOK_SCRIPT)
 
 
-# SHA-256 of roam-shipped historical hook bodies that predate the version stamp.
-# A deployed body whose hash is here is KNOWN to be roam's own past output, so it
-# is safe to heal even though it carries no marker. Seed additions belong here
-# whenever a body changes (compute the prior stamped body's SHA). Empty is fine:
-# stamped bodies heal by version comparison; only pre-stamp bodies need this set.
-_KNOWN_HOOK_BODY_SHAS: frozenset[str] = frozenset()
+# SHA-256 of every hook body roam ever shipped, in DEPLOYED form (stamped where
+# the shipping commit stamped, raw literal before that), plus the deterministic
+# variant compile-code's mode-override surgery produces (cli.py:266-283 there).
+# A deployed body whose hash is here is KNOWN to be roam's own output — safe to
+# heal without a marker. A stamped body whose hash is NOT here has been edited
+# by hand (or by an unknown external transform): report, never auto-overwrite.
+# Regenerate with scripts/seed_hook_body_shas.py after ANY body change — an
+# empty or stale set silently disables healing for pre-stamp installs (the
+# defect that shipped in #77).
+_KNOWN_HOOK_BODY_SHAS: frozenset[str] = frozenset(
+    {
+        "0313b8d53749fa9d188c9e6554b37826ff677cdd166627ab5b613538bb4b4573",  # stop v2 pristine (2026-07-16 18326816)
+        "2c81e646c1102ebd010b6f470d6a153d8b47d68921584e55806de9052da13fa7",  # stop v2 surgered (2026-07-16 18326816)
+        "fd8a7522fe488b6429f159146523524dcab6465ddbdc09aa91a3515a89bf58a2",  # stop pre-stamp (2026-06-10 ffa51bb1)
+        "23dc563a465af1e5e11f698ce2e8f1aa2cbae0959b7fbbd2ade9ce7abd7bebd6",  # stop pre-stamp (2026-06-11 16871343)
+        "6f95e9afb5f19c6479ca72647ffca014effe453bceaeba47d06d83a898bac3fc",  # stop pre-stamp (2026-07-08 118dcf55)
+        "929f2e2bc35b1b75874194d9e1843b8868a4f8795c8dbe47da29c9fe841fbf32",  # stop pre-stamp (2026-07-16 19e74bd5)
+        "cc1b6fdda85ce004c620ff01f0b7096b910395c224c0f723947d5c6d127343c2",  # stop pre-stamp surgered (07-08 118dcf55)
+        "2fe9800b212926cb332a903114534a9891ddb790d54ec1b7aeb90b740bf67b68",  # stop pre-stamp surgered (07-16 19e74bd5)
+        "0a33b73872a9e507521aa8feea09a9b14525ebc7f91ccc6ae5cce0c9cd83c224",  # ups v2 pristine (2026-07-16 18326816)
+        "c01d848b2da0503ca91460858da9a926851c0e6ce2d6a253b7a1f28fdc96aa8d",  # ups pre-stamp (2026-06-10 ffa51bb1)
+        "849c787f92d385f6eb2e2ca832a5cd85b2f29691dd3dc590381db2a05642fd09",  # ups pre-stamp (2026-07-11 dcf7b2af)
+        "527471d9c46f89825d79196bb092340b019d3f42ffbfcc96023ecda8c07d5433",  # ups pre-stamp (2026-07-16 19e74bd5)
+        "9bae32c06f5b850a6faa92ae926294fedc1036f651282d648f9858c6bcd07e41",  # ups pre-stamp (2026-07-16 30801aad)
+    }
+)
 
 
 def _hook_body_version(text: str) -> int | None:
@@ -1137,12 +1158,19 @@ def _hook_body_version(text: str) -> int | None:
 def _hook_heal_state(deployed: str, canonical: str) -> str:
     """Classify a deployed hook body vs the current canonical body.
 
-    - "current"  : byte-identical (or same version) — nothing to do.
-    - "heal"     : roam wrote it (carries our marker, or a known historical SHA)
-                   but it is out of date — safe to refresh.
-    - "foreign"  : no marker and unrecognized SHA — a user customization or an
-                   external manager (e.g. compile-code's surgery). NEVER auto-
-                   overwrite; report it and let --force / the manager handle it.
+    - "current"    : byte-identical, or a KNOWN roam-shipped variant of the
+                     current version (compile-code's surgered form).
+    - "heal"       : a KNOWN roam-shipped body (stamped or pre-stamp, pristine
+                     or surgered) that is out of date — safe to refresh.
+    - "modified"   : carries our version marker but the content is NOT any
+                     body roam ever shipped — a hand-edited (or truncated)
+                     roam body. Report; overwrite only with --force.
+    - "foreign"    : no marker and unrecognized SHA — a user customization or
+                     an external manager. Report; overwrite only with --force.
+
+    Content is verified by SHA against the shipped-body registry in every
+    non-identical case — a version marker alone proves nothing about the rest
+    of the file (a truncated heal or a user edit keeps the marker intact).
     """
     if deployed == canonical:
         return "current"
@@ -1150,28 +1178,60 @@ def _hook_heal_state(deployed: str, canonical: str) -> str:
 
     dver = _hook_body_version(deployed)
     cver = _hook_body_version(canonical)
-    if dver is not None:
-        # roam-stamped: heal if older, else it's a same-version local edit we
-        # leave alone (compile-code surgery keeps the marker but rewrites lines).
-        return "heal" if (cver is not None and dver < cver) else "current"
-    if hashlib.sha256(deployed.encode("utf-8")).hexdigest() in _KNOWN_HOOK_BODY_SHAS:
+    known = hashlib.sha256(deployed.encode("utf-8")).hexdigest() in _KNOWN_HOOK_BODY_SHAS
+    if known:
+        # Same-version known variant = compile-code's surgery on the current
+        # body: leave it alone. Anything else roam shipped is stale.
+        if dver is not None and cver is not None and dver >= cver:
+            return "current"
         return "heal"
-    return "foreign"
+    return "modified" if dver is not None else "foreign"
 
 
 def _scan_hook_bodies(hook_dir: Path, managed: list) -> dict[str, str]:
-    """{filename: heal_state} for each managed hook whose file exists on disk."""
+    """{filename: heal_state} for each managed hook.
+
+    Adds two states beyond :func:`_hook_heal_state`:
+    - "missing"    : file absent (reinstall when the settings entry exists).
+    - "unreadable" : not valid UTF-8 (e.g. saved as UTF-16 by PowerShell) —
+                     report; replaceable only with --force. Never a traceback:
+                     this scan runs inside `compile claude`'s wire path too.
+    """
     out: dict[str, str] = {}
     for _event, filename, canonical in managed:
         p = hook_dir / filename
         if not p.exists():
+            out[filename] = "missing"
             continue
         try:
             deployed = p.read_text(encoding="utf-8")
         except OSError:
+            continue  # transient FS error: report nothing, touch nothing
+        except ValueError:
+            out[filename] = "unreadable"
             continue
         out[filename] = _hook_heal_state(deployed, canonical)
     return out
+
+
+def _write_hook_body(hook_path: Path, script: str) -> None:
+    """Overwrite a hook body atomically, preserving the prior content as .bak.
+
+    Atomic (temp + os.replace) so a crash mid-write can never leave a
+    truncated body behind a valid version stamp; .bak so heal/--force is
+    recoverable (settings.json already gets the same courtesy).
+    """
+    if hook_path.exists():
+        try:
+            old = hook_path.read_bytes()
+        except OSError:
+            old = None
+        if old is not None and old != script.encode("utf-8"):
+            backup = hook_path.parent / (hook_path.name + ".bak")
+            backup.write_bytes(old)
+    tmp = hook_path.parent / (hook_path.name + ".tmp")
+    tmp.write_text(script, encoding="utf-8")
+    os.replace(tmp, hook_path)
 
 
 def _hook_entry_present(settings: dict, event: str, filename: str) -> bool:
@@ -1261,21 +1321,40 @@ def _claude_uninstall_hooks(settings: dict, settings_path: Path, hook_dir: Path,
     return verdict, removed_any
 
 
-def _claude_install_hooks(settings: dict, settings_path: Path, hook_dir: Path, to_install: list) -> str:
-    """Write the hook scripts + merge settings entries (settings.json backed up)."""
+def _claude_install_hooks(
+    settings: dict,
+    settings_path: Path,
+    hook_dir: Path,
+    to_install: list,
+    body_states: dict[str, str] | None = None,
+    force: bool = False,
+) -> tuple[str, list[str]]:
+    """Write the hook scripts + merge settings entries (settings.json backed up).
+
+    A hook whose settings entry is missing but whose FILE on disk is a body
+    roam cannot recognize (user-modified / foreign / unreadable) gets its entry
+    wired while the body is PRESERVED unless --force — a wiped settings.json
+    must not become a license to overwrite a customized body. Returns
+    (verdict_part, preserved_filenames).
+    """
     if settings_path.exists():
         backup = settings_path.with_suffix(".json.bak")
         backup.write_text(settings_path.read_text(encoding="utf-8"), encoding="utf-8")
     hook_dir.mkdir(parents=True, exist_ok=True)
+    preserved: list[str] = []
     for event, filename, script in to_install:
         hook_path = hook_dir / filename
-        hook_path.write_text(script, encoding="utf-8")
-        _make_executable(hook_path)
+        state = (body_states or {}).get(filename)
+        if state in ("modified", "foreign", "unreadable") and not force:
+            preserved.append(filename)
+        else:
+            _write_hook_body(hook_path, script)
+            _make_executable(hook_path)
         _merge_hook_entry(settings, event, f"python3 {hook_path}")
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
     wired = " + ".join(e for e, _f, _s in to_install)
-    return f"Wired roam compile+verify into Claude Code ({wired}): {settings_path}"
+    return f"Wired roam compile+verify into Claude Code ({wired}): {settings_path}", preserved
 
 
 @hooks.command("claude")
@@ -1333,56 +1412,90 @@ def claude_setup(ctx, write, user_level, do_uninstall, no_verify, force):
     # C3 heal: a hook whose settings entry is present but whose BODY on disk is a
     # stale roam-written version (frozen at an older install) is invisible to the
     # settings-based `to_install` above — so it never refreshes and misses new
-    # behaviour (session-id join key, agent-mode stamp). Scan present bodies and
-    # refresh the healable ones; leave foreign (user/external) bodies untouched.
+    # behaviour (session-id join key, agent-mode stamp). Scan bodies and refresh
+    # the ones roam provably shipped; reinstall bodies that vanished while their
+    # entry stayed wired; leave modified/foreign/unreadable bodies untouched
+    # (reported below; --force overwrites, with a .bak).
     body_states = _scan_hook_bodies(hook_dir, managed)
-    heal = [(e, f, s) for e, f, s in managed if body_states.get(f) == "heal" and (e, f, s) not in to_install]
+    heal = [
+        (e, f, s) for e, f, s in managed if body_states.get(f) in ("heal", "missing") and (e, f, s) not in to_install
+    ]
+    forced = []
     if force:
-        heal += [
+        forced = [
             (e, f, s)
             for e, f, s in managed
-            if body_states.get(f) == "foreign" and (e, f, s) not in to_install and (e, f, s) not in heal
+            if body_states.get(f) in ("modified", "foreign", "unreadable")
+            and (e, f, s) not in to_install
+            and (e, f, s) not in heal
         ]
-    foreign = [f for f, st in body_states.items() if st == "foreign" and not force]
+    attention = {f: st for f, st in body_states.items() if st in ("modified", "foreign", "unreadable") and not force}
 
-    if not to_install and not heal:
+    if not to_install and not heal and not forced:
         verdict = f"roam Claude Code hooks wired + current in {settings_path}"
+        if attention:
+            verdict = (
+                f"roam Claude Code hooks wired in {settings_path}; {len(attention)} body(ies) need attention (see NOTE)"
+            )
     elif write:
         parts = []
+        preserved: list[str] = []
         if to_install:
-            parts.append(_claude_install_hooks(settings, settings_path, hook_dir, to_install))
+            installed_verdict, preserved = _claude_install_hooks(
+                settings, settings_path, hook_dir, to_install, body_states=body_states, force=force
+            )
+            parts.append(installed_verdict)
+        surgery_reset = False
+        for _e, filename, script in heal + forced:
+            hook_path = hook_dir / filename
+            try:
+                prior = hook_path.read_text(encoding="utf-8") if hook_path.exists() else ""
+            except (OSError, ValueError):
+                prior = ""
+            if "--override-mode" in prior and "--override-mode" not in script:
+                surgery_reset = True
+            _write_hook_body(hook_path, script)
+            _make_executable(hook_path)
         if heal:
-            for _e, filename, script in heal:
-                (hook_dir / filename).write_text(script, encoding="utf-8")
-                _make_executable(hook_dir / filename)
             parts.append(f"healed {len(heal)} stale hook body(ies): {', '.join(f for _e, f, _s in heal)}")
+        if forced:
+            parts.append(f"force-refreshed {len(forced)} body(ies): {', '.join(f for _e, f, _s in forced)}")
         verdict = "; ".join(parts)
+        # preserved ⊆ attention already (same states, force=False) — the NOTE
+        # below reports them; nothing to overwrite here.
+        if surgery_reset:
+            verdict += "; mode-override surgery reset — re-run `compile claude` to re-apply"
     else:
         actions = []
         if to_install:
             actions.append(f"install {', '.join(f for _e, f, _s in to_install)}")
         if heal:
-            actions.append(f"heal stale body {', '.join(f for _e, f, _s in heal)}")
+            actions.append(f"heal stale/missing body {', '.join(f for _e, f, _s in heal)}")
+        if forced:
+            actions.append(f"force-overwrite unrecognized body {', '.join(f for _e, f, _s in forced)}")
         verdict = f"Would {' and '.join(actions)} (dry-run; add --write)"
 
     text_lines = []
-    if (to_install or heal) and not write:
-        text_lines = ["  hook script : " + str(hook_dir / f) for _e, f, _s in (to_install + heal)]
+    if (to_install or heal or forced) and not write:
+        text_lines = ["  hook script : " + str(hook_dir / f) for _e, f, _s in (to_install + heal + forced)]
         text_lines.append("  settings    : " + str(settings_path))
         text_lines.append("  apply with  : roam hooks claude --write" + (" --user" if user_level else ""))
-    if foreign:
+    if attention:
+        detail = ", ".join(f"{f} ({st})" for f, st in sorted(attention.items()))
         text_lines.append(
-            f"  NOTE: {len(foreign)} hook body(ies) are user-modified or externally managed "
-            f"({', '.join(foreign)}); not healed. Use --force to overwrite."
+            f"  NOTE: {len(attention)} hook body(ies) are user-modified, externally managed, or "
+            f"unreadable ({detail}); not healed. Use --force to overwrite (a .bak is kept)."
         )
     _emit_hooks_verdict(
         json_mode,
         verdict,
         {
             "already_installed": not to_install,
-            "applied": bool(write and (to_install or heal)),
+            "applied": bool(write and (to_install or heal or forced)),
             "healed": [f for _e, f, _s in heal],
-            "foreign_bodies": foreign,
+            "forced": [f for _e, f, _s in forced],
+            "foreign_bodies": sorted(attention),
+            "body_states": body_states,
             "hook_body_version": _HOOK_BODY_VERSION,
         },
         {"settings_path": str(settings_path), "hook_dir": str(hook_dir)},

--- a/tests/test_hooks_claude_setup.py
+++ b/tests/test_hooks_claude_setup.py
@@ -357,50 +357,200 @@ class TestHookBodyHeal:
 
         assert _hook_body_version(_CLAUDE_UPS_HOOK_SCRIPT) == _HOOK_BODY_VERSION
 
-    def test_heal_state_classification(self):
+    @staticmethod
+    def _register(monkeypatch, *bodies: str):
+        """Add synthetic bodies to the shipped-registry for a test."""
+        import hashlib
+
+        from roam.commands import cmd_hooks
+
+        extra = {hashlib.sha256(b.encode("utf-8")).hexdigest() for b in bodies}
+        monkeypatch.setattr(cmd_hooks, "_KNOWN_HOOK_BODY_SHAS", cmd_hooks._KNOWN_HOOK_BODY_SHAS | extra)
+
+    def test_registry_is_seeded(self):
+        """F1 guard: an empty/garbled registry silently disables pre-stamp healing."""
+        from roam.commands.cmd_hooks import _KNOWN_HOOK_BODY_SHAS
+
+        assert len(_KNOWN_HOOK_BODY_SHAS) >= 13
+        assert all(len(s) == 64 and set(s) <= set("0123456789abcdef") for s in _KNOWN_HOOK_BODY_SHAS)
+
+    def test_heal_state_classification(self, monkeypatch):
         from roam.commands.cmd_hooks import _CLAUDE_UPS_HOOK_SCRIPT, _hook_heal_state
 
         canonical = _CLAUDE_UPS_HOOK_SCRIPT
         assert _hook_heal_state(canonical, canonical) == "current"
-        # a roam body stamped with an OLDER version -> healable
-        older = canonical.replace("# roam-hook-version: 2", "# roam-hook-version: 1")
-        assert _hook_heal_state(older, canonical) == "heal"
-        # an unstamped, unrecognized body -> foreign (never auto-overwrite)
-        assert _hook_heal_state("#!/usr/bin/env python3\nprint('mine')\n", canonical) == "foreign"
+        # an older stamp alone proves NOTHING: unknown content -> modified
+        older_unknown = canonical.replace("# roam-hook-version: 2", "# roam-hook-version: 1") + "# my edit\n"
+        assert _hook_heal_state(older_unknown, canonical) == "modified"
+        # a REGISTERED older body (roam provably shipped it) -> healable
+        older_known = canonical.replace("# roam-hook-version: 2", "# roam-hook-version: 1")
+        self._register(monkeypatch, older_known)
+        from roam.commands.cmd_hooks import _hook_heal_state as heal_state
 
-    def test_stale_roam_body_is_healed(self, in_tmp):
+        assert heal_state(older_known, canonical) == "heal"
+        # a registered UNSTAMPED body (pre-stamp era) -> healable
+        prestamp = "#!/usr/bin/env python3\n# an old shipped body\n"
+        self._register(monkeypatch, prestamp)
+        assert heal_state(prestamp, canonical) == "heal"
+        # an unstamped, unrecognized body -> foreign (never auto-overwrite)
+        assert heal_state("#!/usr/bin/env python3\nprint('mine')\n", canonical) == "foreign"
+
+    def test_prestamp_registered_body_is_healed(self, in_tmp, monkeypatch):
+        """F1: the pre-stamp fleet heals via the SHA registry, no marker needed."""
         hook = self._install(in_tmp)
-        # simulate a frozen older install: same body, older version stamp
-        stale = hook.read_text(encoding="utf-8").replace("# roam-hook-version: 2", "# roam-hook-version: 1")
-        hook.write_text(stale, encoding="utf-8")
+        prestamp = "#!/usr/bin/env python3\n# roam body from before the stamp era\n"
+        hook.write_text(prestamp, encoding="utf-8")
+        self._register(monkeypatch, prestamp)
         res = _invoke("claude", "--write")
         assert "healed 1 stale hook body" in res.output
-        # refreshed to current version
         from roam.commands.cmd_hooks import _HOOK_BODY_VERSION, _hook_body_version
 
         assert _hook_body_version(hook.read_text(encoding="utf-8")) == _HOOK_BODY_VERSION
+        # F9: the replaced body is preserved as .bak
+        bak = hook.parent / (hook.name + ".bak")
+        assert bak.read_text(encoding="utf-8") == prestamp
+
+    def test_older_stamped_modified_body_not_healed(self, in_tmp):
+        """F3: a stamped-but-edited body is never silently overwritten."""
+        hook = self._install(in_tmp)
+        edited = (
+            hook.read_text(encoding="utf-8").replace("# roam-hook-version: 2", "# roam-hook-version: 1")
+            + "# my customization\n"
+        )
+        hook.write_text(edited, encoding="utf-8")
+        res = _invoke("claude", "--write")
+        assert "user-modified" in res.output and "(modified)" in res.output
+        assert hook.read_text(encoding="utf-8") == edited  # untouched
+        # --force overwrites, keeping a .bak
+        res = _invoke("claude", "--write", "--force")
+        assert "force-refreshed 1 body(ies)" in res.output
+        assert (hook.parent / (hook.name + ".bak")).read_text(encoding="utf-8") == edited
+
+    def test_truncated_stamped_body_is_not_current(self, in_tmp):
+        """F6a: a truncated body behind an intact stamp must not read as current."""
+        hook = self._install(in_tmp)
+        truncated = "\n".join(hook.read_text(encoding="utf-8").split("\n")[:3]) + "\n"
+        hook.write_text(truncated, encoding="utf-8")
+        res = _invoke("claude", "--write")
+        assert "wired + current" not in res.output
+        assert "need attention" in res.output or "user-modified" in res.output
+
+    def test_missing_body_with_wired_entry_is_reinstalled(self, in_tmp):
+        """F6b: entry present + body file deleted -> body comes back on --write."""
+        hook = self._install(in_tmp)
+        hook.unlink()
+        res = _invoke("claude", "--write")
+        assert "healed 1 stale hook body" in res.output
+        assert hook.exists()
+
+    def test_unreadable_body_no_traceback(self, in_tmp):
+        """F5: a UTF-16 hook body must degrade to a report, never a traceback."""
+        hook = self._install(in_tmp)
+        hook.write_bytes("#!/usr/bin/env python3\nprint('x')\n".encode("utf-16"))
+        res = _invoke("claude", "--write")
+        assert res.exit_code == 0
+        assert res.exception is None
+        assert "(unreadable)" in res.output
+        # untouched without --force
+        assert hook.read_bytes().startswith(b"\xff\xfe")
+        res = _invoke("claude", "--write", "--force")
+        assert "force-refreshed 1 body(ies)" in res.output
+        hook.read_text(encoding="utf-8")  # now valid UTF-8
+
+    def test_wiped_settings_does_not_overwrite_foreign_body(self, in_tmp):
+        """F4: a missing settings entry must not become a license to clobber."""
+        hook = self._install(in_tmp)
+        mine = "#!/usr/bin/env python3\n# my own hook\nprint('custom')\n"
+        hook.write_text(mine, encoding="utf-8")
+        (in_tmp / ".claude" / "settings.json").unlink()
+        res = _invoke("claude", "--write")
+        assert res.exit_code == 0
+        settings = json.loads((in_tmp / ".claude" / "settings.json").read_text())
+        assert _ups_entry_present(settings)  # entry rewired...
+        assert hook.read_text(encoding="utf-8") == mine  # ...body preserved
+        assert "NOTE:" in res.output
 
     def test_foreign_body_not_healed_but_reported(self, in_tmp):
         hook = self._install(in_tmp)
         mine = "#!/usr/bin/env python3\n# my own customized hook\nprint('custom')\n"
         hook.write_text(mine, encoding="utf-8")
         res = _invoke("claude", "--write")
-        assert "user-modified or externally managed" in res.output
+        assert "user-modified" in res.output and "(foreign)" in res.output
         assert hook.read_text(encoding="utf-8") == mine  # untouched
 
     def test_force_overwrites_foreign_body(self, in_tmp):
         hook = self._install(in_tmp)
         hook.write_text("#!/usr/bin/env python3\nprint('custom')\n", encoding="utf-8")
         res = _invoke("claude", "--write", "--force")
-        assert "healed 1 stale hook body" in res.output
+        assert "force-refreshed 1 body(ies)" in res.output
         from roam.commands.cmd_hooks import _HOOK_BODY_VERSION, _hook_body_version
 
         assert _hook_body_version(hook.read_text(encoding="utf-8")) == _HOOK_BODY_VERSION
 
-    def test_dry_run_reports_heal_without_writing(self, in_tmp):
+    def test_dry_run_reports_heal_without_writing(self, in_tmp, monkeypatch):
         hook = self._install(in_tmp)
-        stale = hook.read_text(encoding="utf-8").replace("# roam-hook-version: 2", "# roam-hook-version: 1")
-        hook.write_text(stale, encoding="utf-8")
+        prestamp = "#!/usr/bin/env python3\n# roam body from before the stamp era\n"
+        hook.write_text(prestamp, encoding="utf-8")
+        self._register(monkeypatch, prestamp)
         res = _invoke("claude")  # no --write
-        assert "heal stale body" in res.output and "dry-run" in res.output
-        assert hook.read_text(encoding="utf-8") == stale  # unchanged
+        assert "heal stale/missing body" in res.output and "dry-run" in res.output
+        assert hook.read_text(encoding="utf-8") == prestamp  # unchanged
+
+    def test_dry_run_force_labels_foreign_distinctly(self, in_tmp):
+        """F10: dry-run --force must not call a foreign body a stale heal."""
+        hook = self._install(in_tmp)
+        hook.write_text("#!/usr/bin/env python3\nprint('custom')\n", encoding="utf-8")
+        res = _invoke("claude", "--force")  # no --write
+        assert "force-overwrite unrecognized body" in res.output
+        assert "print('custom')" in hook.read_text(encoding="utf-8")  # untouched
+
+    def test_surgered_current_body_classifies_current(self):
+        """compile-code's mode-override surgery on the CURRENT body stays quiet
+        (its SHA is registered as a shipped variant)."""
+        import re as _re
+
+        from roam.commands.cmd_hooks import _CLAUDE_STOP_HOOK_SCRIPT, _hook_heal_state
+
+        # verbatim copy of compile-code cli.py _override_hook_maintenance_commands
+        script = _CLAUDE_STOP_HOOK_SCRIPT.replace(
+            '["roam", "--json", *args]',
+            '["roam", *(["--override-mode"] if args and args[0] in {"verify", "index"} else []), "--json", *args]',
+        )
+        script = _re.sub(
+            r'(["\']roam["\']\s*,\s*)(["\'])(verify|index)\2',
+            r'\1"--override-mode", \2\3\2',
+            script,
+        )
+        assert script != _CLAUDE_STOP_HOOK_SCRIPT  # surgery actually bites
+        assert _hook_heal_state(script, _CLAUDE_STOP_HOOK_SCRIPT) == "current"
+
+    def test_doctor_reports_hook_body_state(self, in_tmp, monkeypatch):
+        """F7: doctor surfaces non-current bodies (advisory)."""
+        from roam.commands import cmd_hooks
+        from roam.commands.cmd_doctor import _check_claude_hook_bodies
+
+        # isolate the user level from the real box
+        monkeypatch.setattr(
+            cmd_hooks,
+            "_claude_hook_dir",
+            lambda user_level: in_tmp / "userhooks" if user_level else in_tmp / ".claude" / "hooks",
+        )
+        monkeypatch.setattr(
+            cmd_hooks,
+            "_claude_settings_path",
+            lambda user_level: (
+                in_tmp / "userhooks" / "settings.json" if user_level else in_tmp / ".claude" / "settings.json"
+            ),
+        )
+        _invoke("claude", "--write")
+        assert _check_claude_hook_bodies()["passed"] is True
+        hook = in_tmp / ".claude" / "hooks" / _CLAUDE_UPS_HOOK_FILENAME
+        hook.write_text("#!/usr/bin/env python3\nprint('custom')\n", encoding="utf-8")
+        result = _check_claude_hook_bodies()
+        assert result["passed"] is False
+        assert "foreign" in result["detail"]
+        # entry wired + body deleted -> reported, not silently fine
+        hook.unlink()
+        result = _check_claude_hook_bodies()
+        assert result["passed"] is False
+        assert "missing" in result["detail"]


### PR DESCRIPTION
Closes the confirmed findings from the post-merge adversarial review of #77 (see the F1–F10 comment there).

**The core defect:** `_KNOWN_HOOK_BODY_SHAS` shipped empty, so the healing feature #77 was named for never fired for any pre-stamp install — and by design could never match the compile-code-surgered Stop bodies that dominate real deployments.

**What this does:**
- Seeds the registry with all **13 distinct deployed-form bodies** across the file's git history (pristine + surgered variants; `scripts/seed_hook_body_shas.py` regenerates; a test guards non-emptiness).
- **Content-verified heal:** a version marker alone no longer authorizes overwrite — stamped-but-edited or truncated-behind-a-stamp bodies classify `modified` (reported; `--force` + `.bak`). Fixes the F3 silent-clobber and the F6a "truncated reads as current" lie.
- **F4:** wiped settings.json no longer licenses body overwrite — entry is rewired, unrecognized body preserved.
- **F5:** UTF-16 bodies → `unreadable` report, not a traceback (regression `compile claude` would have hit).
- **F6b:** entry-wired-but-deleted bodies reinstall on `--write`.
- **F7:** `roam doctor` gains the advisory "Claude hook bodies" check (both levels, including entry-wired-body-gone).
- **F8/F9/F10:** surgery-reset notice; atomic writes + `.bak`; honest dry-run labels.

12 heal-class tests (was 5). 32/32 file suite; prepush 7/7 (57s).