### PR TITLE
fix(db): a redirected index store leaves the analysed repository untouched

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,9 @@ Yes, after installation and parser prewarming. Run `roam index --force` once whi
 **Does Roam modify my source code?**
 Read-only by default. Creates `.roam/` with an index database. `roam mutate` (move/rename/extract) defaults to `--dry-run`; pass `--apply` explicitly to write changes.
 
+**Can Roam analyse a repository without writing anything into it?**
+Yes. `ROAM_DB_DIR=/path/to/store` (or `roam config --set-db-dir`) redirects the whole index store — the SQLite database *and* its `index.lock` / `index.state` sidecars — so the analysed repository is left byte-identical and no `.roam/` directory appears in it. If the caller must also never trigger a build, set `ROAM_NO_AUTO_INDEX=1`: commands that would otherwise index a repository with no index exit `3` (`INDEX_MISSING`) with a message naming the variable, instead of building one. `roam init` and `roam index` still build normally — the opt-out covers the implicit cold-start build, not the commands you ran on purpose.
+
 **How does Roam handle monorepos and multi-repo projects?**
 Monorepos: indexes from the root; batched SQL handles 100k+ symbols. Multi-repo: `roam ws init <repo1> <repo2>` builds a workspace overlay DB for cross-repo API edges, then `roam ws resolve` / `ws context` / `ws trace` work across repos.
 
@@ -906,7 +909,7 @@ The CLI is Apache 2.0, runs its analysis engine locally, and never expires. Roam
 | Problem | Solution |
 |---------|----------|
 | `roam: command not found` | Ensure install location is on PATH. For `uv`: `uv tool update-shell` |
-| `Another indexing process owns the workspace` | Wait for the other `roam index` to finish. If nothing else is running, the lock is unprovable-stale (`An index lifecycle owner is live or cannot be proven stale`) — delete `.roam/index.lock` and retry |
+| `Another indexing process owns the workspace` | Wait for the other `roam index` to finish. If nothing else is running, the lock is unprovable-stale (`An index lifecycle owner is live or cannot be proven stale`) — delete `index.lock` from the index store (`.roam/` by default, or the `ROAM_DB_DIR` / `--set-db-dir` directory) and retry |
 | `database is locked` | `roam index --force` to rebuild |
 | Unicode errors on Windows | `chcp 65001` for UTF-8 |
 | Symbol resolves to wrong file | Use `file:symbol` syntax: `roam symbol myfile:MyFunction` |
@@ -923,7 +926,7 @@ pipx upgrade roam-code        # or: uv tool upgrade roam-code / pip install --up
 pipx uninstall roam-code      # or: uv tool uninstall roam-code / pip uninstall roam-code
 ```
 
-Delete `.roam/` from your project root to clean up local data.
+Delete `.roam/` from your project root to clean up local data (plus the `ROAM_DB_DIR` / `--set-db-dir` directory if the index store was redirected).
 
 ## Contributing
 

--- a/src/roam/commands/cmd_config.py
+++ b/src/roam/commands/cmd_config.py
@@ -704,7 +704,10 @@ def config(
 
     The setting is saved to ``.roam/config.json`` and takes precedence over
     the default ``.roam/index.db`` location (but the ``ROAM_DB_DIR`` env-var
-    still wins if set).
+    still wins if set). Either override moves the WHOLE index store: the
+    database and the indexer's ``index.lock`` / ``index.state`` sidecars all
+    resolve from the configured directory, so analysing a repository with a
+    redirected store writes nothing into that repository.
     """
     json_mode = ctx.obj.get("json") if ctx.obj else False
     root = find_project_root()

--- a/src/roam/commands/cmd_exit_codes.py
+++ b/src/roam/commands/cmd_exit_codes.py
@@ -22,12 +22,15 @@ _DESCRIPTIONS = {
     "EXIT_ERROR": "Generic failure (unhandled exception, missing file, etc.).",
     "EXIT_USAGE": "Bad arguments or flags. Check `--help`.",
     # The two index rows described an intention, not the program. Verified by
-    # measurement and by grep: `require_index` (the only raiser of
-    # IndexMissingError) is called by nothing, and IndexStaleError is never
-    # raised outside tests -- while the guard family really does return 4 for
-    # `needs_review`. A CI script or agent branching on this table was being
-    # told to `roam index` in response to a human-judgment gate.
-    "EXIT_INDEX_MISSING": "Reserved. No command returns this -- roam auto-indexes instead of refusing.",
+    # measurement and by grep: IndexStaleError is never raised outside tests,
+    # while the guard family really does return 4 for `needs_review`. A CI
+    # script or agent branching on this table was being told to `roam index`
+    # in response to a human-judgment gate. The index-missing row is now
+    # reachable, but only on the opt-out path named in its text.
+    "EXIT_INDEX_MISSING": (
+        "No index and auto-indexing was refused (ROAM_NO_AUTO_INDEX set). "
+        "Run `roam init`. Without that env var roam auto-indexes and never returns this."
+    ),
     "EXIT_INDEX_STALE": (
         "needs_review: a guard verdict (`verdict`, `guard-pr`, `proof-bundle`) requires "
         "a human. Re-running produces the same answer. NOT a stale index."

--- a/src/roam/commands/cmd_init.py
+++ b/src/roam/commands/cmd_init.py
@@ -307,7 +307,7 @@ def init(ctx, root, yes, with_ci, since, full_history):
     # since the user just ran exactly that. cmd_init IS the init path; the
     # advisory belongs on commands that consume an index, not the one
     # building it.
-    ensure_index(quiet=json_mode, suppress_cold_start_advisory=True)
+    ensure_index(quiet=json_mode, suppress_cold_start_advisory=True, explicit_build=True)
 
     # 2b. Self-ignore .roam/ so `roam init` does not dirty `git status`
     # (and so `roam health` does not then report that dirt as index

--- a/src/roam/commands/resolve.py
+++ b/src/roam/commands/resolve.py
@@ -8,7 +8,15 @@ import subprocess
 
 import click
 
-from roam.db.connection import batched_in, db_exists, find_project_root, open_db
+from roam.db.connection import (
+    StaleDbDirError,
+    batched_in,
+    db_exists,
+    find_project_root,
+    get_index_lock_path,
+    get_index_state_path,
+    open_db,
+)
 from roam.db.queries import SEARCH_SYMBOLS, SYMBOL_BY_NAME, SYMBOL_BY_QUALIFIED
 
 
@@ -249,9 +257,18 @@ def _existing_index_recovery_state() -> str | None:
         log_swallowed("resolve:index_recovery_state:find_project_root", exc)
         return None
 
-    roam_dir = root / ".roam"
-    lock_path = roam_dir / "index.lock"
-    state_path = roam_dir / "index.state"
+    # Read the sidecars from the store directory the indexer writes them
+    # to. Reading a fixed ``<root>/.roam`` while the writer honours a
+    # redirect would report every redirected index as having no
+    # lifecycle record at all.
+    try:
+        lock_path = get_index_lock_path(root)
+        state_path = get_index_state_path(root)
+    except (OSError, StaleDbDirError) as exc:
+        from roam.observability import log_swallowed
+
+        log_swallowed("resolve:index_recovery_state:store_dir", exc)
+        return None
 
     from roam.index.indexer import (
         _decode_index_lock,
@@ -302,7 +319,29 @@ def _existing_index_recovery_state() -> str | None:
     return None
 
 
-def ensure_index(quiet: bool = False, suppress_cold_start_advisory: bool = False) -> None:
+def auto_index_disabled() -> bool:
+    """Return ``True`` when the caller opted out of automatic indexing.
+
+    Read-only consumers ask roam questions about a checkout they do not own
+    and have no mandate to write to. Every analysis command auto-indexes on
+    a cold start, which turns "answer this question" into "build an index
+    first" — minutes of work and a store the caller never asked for.
+    Setting ``ROAM_NO_AUTO_INDEX`` to a truthy value (``1``/``true``/``yes``/
+    ``on``) makes those commands refuse with the typed
+    :class:`roam.exit_codes.IndexMissingError` (exit 3) instead, so the
+    caller can build the index deliberately with ``roam init`` — under its
+    own ``ROAM_DB_DIR`` if it wants the store elsewhere.
+
+    Unset (the default) preserves the historical auto-index behaviour.
+    """
+    return os.environ.get("ROAM_NO_AUTO_INDEX", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def ensure_index(
+    quiet: bool = False,
+    suppress_cold_start_advisory: bool = False,
+    explicit_build: bool = False,
+) -> None:
     """Build the index if it doesn't exist yet.
 
     Args:
@@ -312,6 +351,15 @@ def ensure_index(quiet: bool = False, suppress_cold_start_advisory: bool = False
             commands whose PURPOSE is to build the index (``roam init``) — the
             user just asked to create the index, so recommending they run the
             command they're already running is confusing first-time UX (W1291).
+        explicit_build: If True, the caller IS the build command (``roam init``)
+            and ``ROAM_NO_AUTO_INDEX`` does not apply to it. The opt-out exists
+            so a read-only consumer's ANALYSIS call refuses instead of writing;
+            applying it to the escape hatch the refusal recommends would leave
+            the caller with no way to build an index at all. This is a separate
+            argument rather than a reuse of ``suppress_cold_start_advisory``
+            because the two answer different questions (what to print vs.
+            whether writing is permitted), and a shared flag would silently
+            couple them.
     """
     index_exists = db_exists()
     recovery_state = _existing_index_recovery_state() if index_exists else None
@@ -320,6 +368,20 @@ def ensure_index(quiet: bool = False, suppress_cold_start_advisory: bool = False
             "The roam index is currently being built by another process. Retry after that index run completes."
         )
     if not index_exists or recovery_state == "incomplete":
+        if auto_index_disabled() and not explicit_build:
+            from roam.exit_codes import IndexMissingError
+
+            missing = (
+                "no usable roam index"
+                if not index_exists
+                else "the roam index is incomplete after an interrupted build"
+            )
+            raise IndexMissingError(
+                f"Refusing to index: {missing}, and ROAM_NO_AUTO_INDEX is set. "
+                "Run `roam init` to build one (set ROAM_DB_DIR first to keep the store "
+                "outside this repository), or unset ROAM_NO_AUTO_INDEX to let this "
+                "command index."
+            )
         if not quiet and not suppress_cold_start_advisory:
             if recovery_state == "incomplete":
                 click.echo("Incomplete roam index detected after an interrupted build. Rebuilding it before analysis.")

--- a/src/roam/db/connection.py
+++ b/src/roam/db/connection.py
@@ -25,6 +25,13 @@ WarningsOut = list[str] | None
 
 DEFAULT_DB_DIR = ".roam"
 DEFAULT_DB_NAME = "index.db"
+#: Control sidecars of the index database. They are part of the same
+#: store as ``index.db``: the indexer takes ``index.lock`` for mutual
+#: exclusion and publishes its lifecycle in ``index.state``. Resolving
+#: them anywhere other than the database's own directory splits one
+#: store across two locations — see :func:`get_db_dir`.
+INDEX_LOCK_NAME = "index.lock"
+INDEX_STATE_NAME = "index.state"
 
 
 class StaleDbDirError(RuntimeError):
@@ -223,8 +230,8 @@ def write_project_config(config: dict, project_root: Path | None = None) -> Path
     return config_path
 
 
-def get_db_path(project_root: Path | None = None) -> Path:
-    """Get the path to the index database.
+def get_db_dir(project_root: Path | None = None, *, create: bool = True) -> Path:
+    """Get the directory that holds the index database and its sidecars.
 
     Resolution order (first match wins):
 
@@ -232,21 +239,57 @@ def get_db_path(project_root: Path | None = None) -> Path:
        useful when the project lives on OneDrive/Dropbox or a network drive.
     2. ``.roam/config.json`` → ``"db_dir"`` key — persistent per-project
        alternative to the env-var (write once with ``roam config``).
-    3. Default: ``<project_root>/.roam/index.db``.
+    3. Default: ``<project_root>/.roam``.
+
+    This is the ONE resolver for the whole store. ``index.db`` and every
+    control sidecar (``index.lock``, ``index.state``) are derived from the
+    directory returned here, so a redirect moves the complete store and a
+    sidecar added later follows it without a second edit.
+
+    ``create=False`` resolves the path without materialising the directory.
+    A pure predicate must not have a filesystem side effect: ``db_exists``
+    only ASKS whether an index is there, and creating the store directory to
+    answer that put a ``.roam/`` into every repository a read-only caller so
+    much as looked at. Writers keep the default ``create=True`` because they
+    are about to put a file in the directory they are asking for.
+
+    Before this function existed the database honoured the redirect while
+    the indexer hard-coded ``<project_root>/.roam/index.lock`` and
+    ``<project_root>/.roam/index.state``. A caller that redirected the store
+    precisely so it would not write into a repository it does not own still
+    got a ``.roam/`` directory created there — and because read-only
+    commands auto-index on a cold start, that was the default outcome rather
+    than an edge case.
     """
+
+    def _resolved(candidate: Path | str, source: str) -> Path:
+        return _safe_mkdir(candidate, source=source) if create else Path(candidate)
+
     override = os.environ.get("ROAM_DB_DIR")
     if override:
-        db_dir = _safe_mkdir(override, source="ROAM_DB_DIR env")
-        return db_dir / DEFAULT_DB_NAME
+        return _resolved(override, "ROAM_DB_DIR env")
     if project_root is None:
         project_root = find_project_root()
     # Check .roam/config.json for a db_dir override
     config = _load_project_config(project_root)
     if config.get("db_dir"):
-        db_dir = _safe_mkdir(config["db_dir"], source=".roam/config.json db_dir")
-        return db_dir / DEFAULT_DB_NAME
-    db_dir = _safe_mkdir(project_root / DEFAULT_DB_DIR, source="<project default>")
-    return db_dir / DEFAULT_DB_NAME
+        return _resolved(config["db_dir"], ".roam/config.json db_dir")
+    return _resolved(project_root / DEFAULT_DB_DIR, "<project default>")
+
+
+def get_db_path(project_root: Path | None = None, *, create: bool = True) -> Path:
+    """Get the path to the index database (``index.db`` inside :func:`get_db_dir`)."""
+    return get_db_dir(project_root, create=create) / DEFAULT_DB_NAME
+
+
+def get_index_lock_path(project_root: Path | None = None) -> Path:
+    """Get the path to the indexer's mutual-exclusion lock sidecar."""
+    return get_db_dir(project_root) / INDEX_LOCK_NAME
+
+
+def get_index_state_path(project_root: Path | None = None) -> Path:
+    """Get the path to the indexer's lifecycle-marker sidecar."""
+    return get_db_dir(project_root) / INDEX_STATE_NAME
 
 
 def _is_cloud_synced(path: Path) -> bool:
@@ -1022,8 +1065,15 @@ def __getattr__(name: str):
 
 
 def db_exists(project_root: Path | None = None) -> bool:
-    """Check if an index database exists."""
-    path = get_db_path(project_root)
+    """Check if an index database exists.
+
+    Resolves with ``create=False``: a question about the store must not
+    build part of it. A stale or unwritable configured directory therefore
+    answers ``False`` here instead of raising ``StaleDbDirError``; the
+    structured error still fires on the next real write, which is where a
+    remediation hint belongs.
+    """
+    path = get_db_path(project_root, create=False)
     return path.exists() and path.stat().st_size > 0
 
 

--- a/src/roam/exit_codes.py
+++ b/src/roam/exit_codes.py
@@ -15,12 +15,15 @@ REACHABILITY -- what a caller branching on this table will actually receive.
 This section exists because the table above was, for two of its rows, a
 description of an intention rather than of the program.
 
-* 3 (INDEX_MISSING) is returned by NO shipped command. The only helper that
-  raises ``IndexMissingError`` is ``roam.commands.resolve.require_index``,
-  which nothing in ``src/roam`` calls: commands auto-index instead of
-  refusing, so a repo with no ``.roam/index.db`` gets an index, not exit 3.
-  Measured in a fresh repo: ``roam search`` / ``roam health`` / ``roam dead``
-  all exit 0.
+* 3 (INDEX_MISSING) is returned only when a caller has opted out of
+  automatic indexing. By default commands auto-index instead of refusing,
+  so a repo with no index gets one, not exit 3: measured in a fresh repo,
+  ``roam search`` / ``roam health`` / ``roam dead`` all exit 0. With
+  ``ROAM_NO_AUTO_INDEX`` set to a truthy value,
+  ``roam.commands.resolve.ensure_index`` raises ``IndexMissingError`` on a
+  cold start and every analysis command exits 3 instead of building an
+  index. ``roam.commands.resolve.require_index`` raises the same error and
+  is still called by nothing in ``src/roam``.
 
 * 4 (INDEX_STALE) is returned by NO command with that meaning --
   ``IndexStaleError`` is never raised outside tests. The integer 4 IS
@@ -82,7 +85,9 @@ DESCRIPTIONS: dict[int, str] = {
     EXIT_SUCCESS: "success",
     EXIT_ERROR: "unexpected error",
     EXIT_USAGE: "invalid usage (bad arguments or flags)",
-    EXIT_INDEX_MISSING: "index not found -- run `roam init` (reserved; no command returns this)",
+    EXIT_INDEX_MISSING: (
+        "index not found -- run `roam init` (returned only when ROAM_NO_AUTO_INDEX disables the auto-index path)"
+    ),
     EXIT_INDEX_STALE: "needs_review -- a guard verdict requires a human; re-running will not change it",
     EXIT_GATE_FAILURE: "quality gate failed",
     EXIT_PARTIAL: "partial results (completed with warnings)",

--- a/src/roam/index/indexer.py
+++ b/src/roam/index/indexer.py
@@ -19,7 +19,15 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 from roam.atomic_io import atomic_write_text
-from roam.db.connection import batched_in, find_project_root, get_db_path, open_db
+from roam.db.connection import (
+    INDEX_STATE_NAME,
+    batched_in,
+    find_project_root,
+    get_db_path,
+    get_index_lock_path,
+    get_index_state_path,
+    open_db,
+)
 from roam.index.discovery import discover_files
 
 # Static reference to the Django post-resolver entry point. It is invoked
@@ -609,7 +617,7 @@ def _claim_index_lock(lock_path: Path) -> _IndexLockClaim | None:
         except (OSError, UnicodeError):
             _log("Could not read the held index lock generation. Exiting.")
             return None
-        recovery = _recovery_requirement(lock_path.with_name("index.state"), prior_lock_raw)
+        recovery = _recovery_requirement(lock_path.with_name(INDEX_STATE_NAME), prior_lock_raw)
         if recovery is None:
             _log("An index lifecycle owner is live or cannot be proven stale. Exiting.")
             return None
@@ -1788,12 +1796,15 @@ class Indexer:
         _quiet_mode = quiet
         self._log(f"Indexing {self.root}")
 
-        # Lock file to prevent concurrent indexing
-        lock_path = self.root / ".roam" / "index.lock"
+        # Lock file to prevent concurrent indexing. The lock and the
+        # lifecycle marker are sidecars of the DATABASE, not of the
+        # analysed tree, so both resolve from the store directory: a
+        # redirected store leaves the indexed repository untouched.
+        lock_path = get_index_lock_path(self.root)
         claim = _claim_index_lock(lock_path)
         if claim is None:
             return False
-        state_path = self.root / ".roam" / "index.state"
+        state_path = get_index_state_path(self.root)
         effective_force = force or claim.recovery_required
         effective_light = light and not claim.recovery_required
         if claim.recovery_required:

--- a/tests/test_db_dir_store_is_whole.py
+++ b/tests/test_db_dir_store_is_whole.py
@@ -1,0 +1,185 @@
+"""The index store is one directory: database, lock and lifecycle marker.
+
+``ROAM_DB_DIR`` exists so a caller can analyse a repository without writing
+into it -- a tool inspecting a checkout it does not own, a sandbox with no
+write budget, a project on a cloud-synced drive. The database honoured that
+redirect; the indexer did not. It hard-coded ``<root>/.roam/index.lock`` and
+``<root>/.roam/index.state``, so a redirected run still created a ``.roam/``
+directory in the analysed repository. Because the read-only commands
+auto-index on a cold start, that was the DEFAULT outcome of pointing roam at
+a fresh repository, not a corner case.
+
+Falsification record. Each assertion below was run against the unfixed tree
+first and observed to fail; the recorded text is verbatim.
+
+* ``test_redirected_store_leaves_the_repository_untouched``::
+
+      AssertionError: redirected run wrote roam files into the analysed repo:
+      ['.roam', '.roam/index.lock', '.roam/index.state']
+
+* ``test_refuses_instead_of_indexing_when_auto_index_disabled`` first failed
+  with ``assert 0 == 3`` -- ``ROAM_NO_AUTO_INDEX`` did not exist, so the
+  command indexed the repository and exited 0 instead of refusing. With the
+  refusal in place it failed a second time, on the residue::
+
+      AssertionError: a refused run still wrote into the repo: ['.roam']
+
+  because ``db_exists`` resolved the store path with the directory-creating
+  helper: merely ASKING whether an index existed created ``.roam/``.
+
+* ``test_one_resolver_places_database_lock_and_marker_together`` and
+  ``test_auto_index_disabled_reads_only_truthy_values`` failed on import --
+  neither ``get_db_dir`` nor ``auto_index_disabled`` existed.
+
+Two tests are controls and passed before the fix as well as after:
+``test_default_store_keeps_every_file_in_the_project_roam_dir`` (no redirect
+configured, so all three files must still land in ``<root>/.roam`` exactly as
+they always have) and ``test_explicit_init_still_builds_when_auto_index_
+disabled`` (the opt-out must not disable the command the refusal recommends).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+# Names that belong to the roam store. ``.git`` is excluded by the walk below
+# because git keeps its own unrelated ``index.lock``.
+_STORE_NAMES = frozenset({".roam", "index.db", "index.lock", "index.state"})
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store_env(monkeypatch):
+    """A developer's own ``ROAM_DB_DIR`` must not decide these outcomes."""
+    monkeypatch.delenv("ROAM_DB_DIR", raising=False)
+    monkeypatch.delenv("ROAM_NO_AUTO_INDEX", raising=False)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A tiny committed git repository with one resolvable symbol."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "app.py").write_text(
+        "def helper():\n    return 1\n\n\ndef caller():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=project, capture_output=True, check=False)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=project, capture_output=True, check=False)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=project, capture_output=True, check=False)
+    subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=False)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=project, capture_output=True, check=False)
+    return project
+
+
+def _store_entries(root: Path) -> list[str]:
+    """Every roam-store path under *root*, ignoring git's own bookkeeping."""
+    return sorted(
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.name in _STORE_NAMES and ".git" not in path.relative_to(root).parts
+    )
+
+
+def _run_cli(project: Path, argv: list[str]):
+    from roam.cli import cli
+
+    runner = CliRunner()
+    previous = os.getcwd()
+    try:
+        os.chdir(str(project))
+        return runner.invoke(cli, argv, catch_exceptions=False)
+    finally:
+        os.chdir(previous)
+
+
+def test_redirected_store_leaves_the_repository_untouched(repo, tmp_path, monkeypatch):
+    """With ``ROAM_DB_DIR`` set, a cold-start analysis writes nothing into the repo."""
+    store = tmp_path / "store"
+    monkeypatch.setenv("ROAM_DB_DIR", str(store))
+
+    result = _run_cli(repo, ["preflight", "helper"])
+    assert result.exit_code == 0, result.output
+
+    strays = _store_entries(repo)
+    assert strays == [], f"redirected run wrote roam files into the analysed repo: {strays}"
+
+    # The whole store, not just the database, moved to the redirect target.
+    for name in ("index.db", "index.lock", "index.state"):
+        assert (store / name).exists(), (
+            f"{name} missing from the redirected store: {sorted(p.name for p in store.iterdir())}"
+        )
+
+
+def test_default_store_keeps_every_file_in_the_project_roam_dir(repo):
+    """Control: with no redirect, the store stays where it always was."""
+    result = _run_cli(repo, ["preflight", "helper"])
+    assert result.exit_code == 0, result.output
+
+    roam_dir = repo / ".roam"
+    for name in ("index.db", "index.lock", "index.state"):
+        assert (roam_dir / name).exists(), f"{name} missing from {roam_dir}"
+
+
+def test_one_resolver_places_database_lock_and_marker_together(repo, tmp_path, monkeypatch):
+    """All three paths derive from one directory, so a fourth file would too."""
+    from roam.db.connection import (
+        get_db_dir,
+        get_db_path,
+        get_index_lock_path,
+        get_index_state_path,
+    )
+
+    def parents() -> set[Path]:
+        return {
+            get_db_path(repo).parent,
+            get_index_lock_path(repo).parent,
+            get_index_state_path(repo).parent,
+        }
+
+    assert parents() == {get_db_dir(repo)} == {repo / ".roam"}
+
+    store = tmp_path / "elsewhere"
+    monkeypatch.setenv("ROAM_DB_DIR", str(store))
+    assert parents() == {get_db_dir(repo)} == {store}
+
+
+def test_refuses_instead_of_indexing_when_auto_index_disabled(repo, monkeypatch):
+    """``ROAM_NO_AUTO_INDEX`` turns a cold start into a typed refusal, not a build."""
+    from roam.exit_codes import EXIT_INDEX_MISSING
+
+    monkeypatch.setenv("ROAM_NO_AUTO_INDEX", "1")
+
+    result = _run_cli(repo, ["preflight", "helper"])
+    assert result.exit_code == EXIT_INDEX_MISSING, result.output
+    assert "ROAM_NO_AUTO_INDEX" in result.output, result.output
+
+    strays = _store_entries(repo)
+    assert strays == [], f"a refused run still wrote into the repo: {strays}"
+
+
+def test_explicit_init_still_builds_when_auto_index_disabled(repo, monkeypatch):
+    """The refusal recommends ``roam init``; the opt-out must not block it."""
+    monkeypatch.setenv("ROAM_NO_AUTO_INDEX", "1")
+
+    result = _run_cli(repo, ["init"])
+    assert result.exit_code == 0, result.output
+    assert (repo / ".roam" / "index.db").exists(), result.output
+
+
+def test_auto_index_disabled_reads_only_truthy_values(monkeypatch):
+    """An unset or falsy value keeps the historical auto-index behaviour."""
+    from roam.commands.resolve import auto_index_disabled
+
+    monkeypatch.delenv("ROAM_NO_AUTO_INDEX", raising=False)
+    assert auto_index_disabled() is False
+    for falsy in ("", "0", "false", "no", "off"):
+        monkeypatch.setenv("ROAM_NO_AUTO_INDEX", falsy)
+        assert auto_index_disabled() is False, falsy
+    for truthy in ("1", "true", "TRUE", "yes", "on", " 1 "):
+        monkeypatch.setenv("ROAM_NO_AUTO_INDEX", truthy)
+        assert auto_index_disabled() is True, truthy


### PR DESCRIPTION
## The defect

`ROAM_DB_DIR` (and the `.roam/config.json` `db_dir` override) exist so a caller can
analyse a repository without writing into it. The **database** honoured the redirect;
the **indexer did not**. It hard-coded `<root>/.roam/index.lock` and
`<root>/.roam/index.state`, so a redirected run still created a `.roam/` directory in
the analysed tree. Because the read-only commands auto-index on a cold start, that was
the *default* outcome of pointing roam at a fresh repository, not a corner case.

Measured before the fix, `ROAM_DB_DIR=<store> roam preflight <symbol>` in a fresh
one-file repository:

```
repo/   ->  a.py  .git  .roam/{index.lock,index.state}
store/  ->  index.db  index.db-shm  index.db-wal
```

After:

```
repo/   ->  a.py  .git
store/  ->  index.db  index.db-shm  index.db-wal  index.lock  index.state
```

## What changed

- **One resolver.** `get_db_dir()` resolves the store directory; `get_db_path`,
  `get_index_lock_path` and `get_index_state_path` all derive from it, so a sidecar
  added later follows a redirect without a second edit. With no override configured
  every file lands in `<root>/.roam` exactly as before.
- **`db_exists()` resolves with `create=False`.** A question about the store must not
  build part of it — the directory-creating resolver meant that merely *asking* whether
  an index existed left a `.roam/` behind, which is how even a refusal could still
  write. A stale/unwritable configured directory now answers `False` there instead of
  raising `StaleDbDirError`; the structured error still fires on the next real write.
- **`ROAM_NO_AUTO_INDEX`** — the read-only opt-out that did not exist. Truthy
  (`1`/`true`/`yes`/`on`) makes `ensure_index` refuse with the typed
  `IndexMissingError` (exit 3) instead of building. `roam init` passes
  `explicit_build=True` and is unaffected: the opt-out covers the implicit cold-start
  build, not the command the refusal recommends.
- Exit 3 is reachable now, so the exit-code catalogue that documented it as returned by
  nothing is corrected, along with the README FAQ and the `roam config` help text.

## Falsification record

Every new assertion was run against the unfixed tree first and observed to fail:

| test | red on unfixed tree |
|---|---|
| `test_redirected_store_leaves_the_repository_untouched` | `AssertionError: redirected run wrote roam files into the analysed repo: ['.roam', '.roam/index.lock', '.roam/index.state']` |
| `test_refuses_instead_of_indexing_when_auto_index_disabled` | `assert 0 == 3` (env var did not exist), then `AssertionError: a refused run still wrote into the repo: ['.roam']` after the refusal landed but before `db_exists` stopped creating directories |
| `test_one_resolver_places_database_lock_and_marker_together` | `ImportError: cannot import name 'get_db_dir'` |
| `test_auto_index_disabled_reads_only_truthy_values` | `ImportError: cannot import name 'auto_index_disabled'` |

Two controls passed before *and* after:
`test_default_store_keeps_every_file_in_the_project_roam_dir` (no redirect: the store
stays in `<root>/.roam`) and `test_explicit_init_still_builds_when_auto_index_disabled`.

## Tests

Runner: `pytest` (repo default, `pytest tests/`).

- Clean full-suite baseline on the unedited tree at the branch point: exit **1**,
  **16 pre-existing failures** (unrelated: defer-loading, taint/mcp sampling,
  situation-compounds, dogfood-security, doctor-breadcrumb, init-guards,
  gate-channel-parity, w12-dimension, reachability-triage).
- New module `tests/test_db_dir_store_is_whole.py`: 6 tests, exit **0**.
- Affected selection (119 files that reference `get_db_path` / `db_exists` /
  `ensure_index` / `ROAM_DB_DIR` / `index.lock` / `index.state` / exit codes /
  `db_dir`), 3,385 tests: exit **1**, **3 failures — all three in the pre-existing 16**
  and byte-identical to baseline. No new failure.
- `ruff format` / `ruff check` clean; commit and push hooks (leak scan, count drift,
  structural drift-guards) all green.

## Not changed (found, out of scope)

Other `.roam/`-hard-coding readers that do not honour a redirect and are unrelated to
the indexer's write path: `mcp_extras/completions.py` (`.roam/index.db` existence walk
and direct open), `workspace/config.py`, and several staleness probes in
`plan/compiler.py` / `plan/plan_cache.py`. Separately, other repo-local substrates
(run ledger, guard log, memory store, constitution, telemetry, pr-bundles, daemon,
mode file) legitimately live under `.roam/` and are not part of the index store; none
of them fire on the read-only analysis path measured above.
